### PR TITLE
[codex] Add Luau language support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,6 +947,7 @@ dependencies = [
  "tree-sitter-java",
  "tree-sitter-javascript",
  "tree-sitter-kotlin-ng",
+ "tree-sitter-luau",
  "tree-sitter-objc",
  "tree-sitter-php",
  "tree-sitter-python",
@@ -1577,6 +1578,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-luau"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "871abeb427d719788bb38094facd7ff082908ef2b93c1d3d6a5f6025330120f4"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-objc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,8 +94,8 @@ tree-sitter-objc = "3.0.2"
 tree-sitter-php = "0.24"
 tree-sitter-zig = "1.1.2"
 tree-sitter-kotlin-ng = "1.1.0"
+tree-sitter-luau = "1.2.0"
 
 [dev-dependencies]
 tempfile = "3"
 criterion = { version = "0.8", features = ["html_reports"] }
-

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ AI coding agents default to reading whole files. With pitlane-mcp, they fetch on
 
 ## Features
 
-- **AST-based indexing** — tree-sitter parses Rust, Python, JavaScript, TypeScript, C, C++, Go, Java, C#, Ruby, Swift, Objective-C, PHP, Zig, Kotlin, Luau, and Bash source into structured symbols
+- **AST-based indexing** — tree-sitter parses Rust, Python, JavaScript, TypeScript, C, C++, Go, Java, C#, Ruby, Swift, Objective-C, PHP, Zig, Kotlin, Lua, and Bash source into structured symbols
 - **Ten MCP tools** for navigation: outline, search, fetch, line-range fetch, find usages, index stats, usage stats
 - **Incremental re-indexing** — background watcher re-parses only changed files
 - **Disk-persisted index** — binary format, loads in milliseconds on subsequent calls
@@ -36,7 +36,7 @@ AI coding agents default to reading whole files. With pitlane-mcp, they fetch on
 | Objective-C | `.m`, `.mm` | class, protocol, method, function, type alias |
 | PHP | `.php` | class, interface, enum, method, function |
 | Zig | `.zig` | function, method, struct, enum, const |
-| Luau | `.luau`, `.lua` | function, method, type alias |
+| Lua | `.luau`, `.lua` | function, method, type alias |
 | Kotlin | `.kt`, `.kts` | class, interface, enum, object, function, method, type alias |
 
 TypeScript declaration files (`.d.ts`, `.d.mts`, `.d.cts`) are automatically skipped.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ AI coding agents default to reading whole files. With pitlane-mcp, they fetch on
 
 ## Features
 
-- **AST-based indexing** — tree-sitter parses Rust, Python, JavaScript, TypeScript, C, C++, Go, Java, C#, Ruby, Swift, Objective-C, PHP, Zig, Kotlin, and Bash source into structured symbols
+- **AST-based indexing** — tree-sitter parses Rust, Python, JavaScript, TypeScript, C, C++, Go, Java, C#, Ruby, Swift, Objective-C, PHP, Zig, Kotlin, Luau, and Bash source into structured symbols
 - **Ten MCP tools** for navigation: outline, search, fetch, line-range fetch, find usages, index stats, usage stats
 - **Incremental re-indexing** — background watcher re-parses only changed files
 - **Disk-persisted index** — binary format, loads in milliseconds on subsequent calls
@@ -36,6 +36,7 @@ AI coding agents default to reading whole files. With pitlane-mcp, they fetch on
 | Objective-C | `.m`, `.mm` | class, protocol, method, function, type alias |
 | PHP | `.php` | class, interface, enum, method, function |
 | Zig | `.zig` | function, method, struct, enum, const |
+| Luau | `.luau`, `.lua` | function, method, type alias |
 | Kotlin | `.kt`, `.kts` | class, interface, enum, object, function, method, type alias |
 
 TypeScript declaration files (`.d.ts`, `.d.mts`, `.d.cts`) are automatically skipped.
@@ -407,7 +408,7 @@ pitlane-mcp is a fully local tool with no network calls. The following design pr
 `index_project`, `find_usages`, and `watch_project` accept any path accessible to the running process — there is no allowlist or project-root confinement. An AI agent (or a prompt-injected instruction) can call these tools with sensitive directories such as `~/.ssh`, `~/.config`, or `/etc`.
 
 Mitigating factors:
-- Only files with recognized source extensions are indexed or read (`.rs`, `.py`, `.js`, `.ts`, `.tsx`, `.c`, `.cpp`, `.h`, `.hpp`, `.go`, `.swift`, `.m`, `.mm`, `.php`, `.zig`, etc.). Most sensitive files — SSH keys, certificates, `.env` files — have no matching extension and are silently skipped.
+- Only files with recognized source extensions are indexed or read (`.rs`, `.py`, `.js`, `.ts`, `.tsx`, `.c`, `.cpp`, `.h`, `.hpp`, `.go`, `.swift`, `.m`, `.mm`, `.php`, `.zig`, `.luau`, `.lua`, etc.). Most sensitive files — SSH keys, certificates, `.env` files — have no matching extension and are silently skipped.
 - Symbolic links are never followed (`follow_links: false` in all directory walks).
 - Files larger than 1 MiB are skipped.
 

--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@
 ### Language support _(current)_
 
 - [x] **PHP** — `tree-sitter-php` exists on crates.io; massive web ecosystem (WordPress, Laravel, Symfony)
-- [ ] **Lua** — `tree-sitter-lua` exists on crates.io; widely used in game scripting (Roblox, WoW) and embedded configs (Neovim, nginx)
+- [x] **Luau / Roblox Lua** — `tree-sitter-luau` exists on crates.io; covers modern Roblox `.luau` and `.lua` codebases
 - [x] **Zig** — `tree-sitter-zig` exists on crates.io; growing systems-programming language with increasing adoption
 - [x] **Kotlin** — `tree-sitter-kotlin-ng` (v1.1.0); primary language for Android development and popular on the JVM
 

--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@
 ### Language support _(current)_
 
 - [x] **PHP** — `tree-sitter-php` exists on crates.io; massive web ecosystem (WordPress, Laravel, Symfony)
-- [x] **Luau / Roblox Lua** — `tree-sitter-luau` exists on crates.io; covers modern Roblox `.luau` and `.lua` codebases
+- [x] **Lua / Roblox Lua** — `tree-sitter-luau` exists on crates.io; covers modern Roblox `.luau` and `.lua` codebases
 - [x] **Zig** — `tree-sitter-zig` exists on crates.io; growing systems-programming language with increasing adoption
 - [x] **Kotlin** — `tree-sitter-kotlin-ng` (v1.1.0); primary language for Android development and popular on the JVM
 

--- a/src/indexer/language.rs
+++ b/src/indexer/language.rs
@@ -22,7 +22,7 @@ pub enum Language {
     Php,
     Zig,
     Kotlin,
-    Luau,
+    Lua,
 }
 
 impl std::fmt::Display for Language {
@@ -44,7 +44,7 @@ impl std::fmt::Display for Language {
             Language::Php => write!(f, "php"),
             Language::Zig => write!(f, "zig"),
             Language::Kotlin => write!(f, "kotlin"),
-            Language::Luau => write!(f, "luau"),
+            Language::Lua => write!(f, "lua"),
         }
     }
 }
@@ -161,7 +161,7 @@ mod tests {
         assert_eq!(Language::C.to_string(), "c");
         assert_eq!(Language::Cpp.to_string(), "cpp");
         assert_eq!(Language::Kotlin.to_string(), "kotlin");
-        assert_eq!(Language::Luau.to_string(), "luau");
+        assert_eq!(Language::Lua.to_string(), "lua");
     }
 
     #[test]

--- a/src/indexer/language.rs
+++ b/src/indexer/language.rs
@@ -22,6 +22,7 @@ pub enum Language {
     Php,
     Zig,
     Kotlin,
+    Luau,
 }
 
 impl std::fmt::Display for Language {
@@ -43,6 +44,7 @@ impl std::fmt::Display for Language {
             Language::Php => write!(f, "php"),
             Language::Zig => write!(f, "zig"),
             Language::Kotlin => write!(f, "kotlin"),
+            Language::Luau => write!(f, "luau"),
         }
     }
 }
@@ -158,6 +160,8 @@ mod tests {
         assert_eq!(Language::Python.to_string(), "python");
         assert_eq!(Language::C.to_string(), "c");
         assert_eq!(Language::Cpp.to_string(), "cpp");
+        assert_eq!(Language::Kotlin.to_string(), "kotlin");
+        assert_eq!(Language::Luau.to_string(), "luau");
     }
 
     #[test]

--- a/src/indexer/lua.rs
+++ b/src/indexer/lua.rs
@@ -4,11 +4,11 @@ use tree_sitter::{Node, Tree};
 
 use crate::indexer::language::{make_symbol_id, Language, LanguageParser, Symbol, SymbolKind};
 
-pub struct LuauParser;
+pub struct LuaParser;
 
-impl LanguageParser for LuauParser {
+impl LanguageParser for LuaParser {
     fn language(&self) -> Language {
-        Language::Luau
+        Language::Lua
     }
 
     fn extensions(&self) -> &[&str] {
@@ -35,7 +35,7 @@ fn get_signature(source: &[u8], node: Node) -> Option<String> {
     Some(text.lines().next()?.trim_end().to_string())
 }
 
-/// Walk backwards through preceding siblings collecting contiguous Luau comments.
+/// Walk backwards through preceding siblings collecting contiguous Lua comments.
 fn get_doc_comment(source: &[u8], node: Node) -> Option<String> {
     let mut docs = Vec::new();
     let mut prev = node.prev_sibling();
@@ -73,7 +73,7 @@ fn push_symbol(
         name,
         qualified,
         kind,
-        language: Language::Luau,
+        language: Language::Lua,
         file: Arc::new(path.to_path_buf()),
         byte_start: node.start_byte(),
         byte_end: node.end_byte(),
@@ -270,7 +270,7 @@ mod tests {
             .set_language(&tree_sitter_luau::LANGUAGE.into())
             .unwrap();
         let tree = parser.parse(source, None).unwrap();
-        LuauParser.extract_symbols(source, &tree, Path::new(path))
+        LuaParser.extract_symbols(source, &tree, Path::new(path))
     }
 
     #[test]
@@ -358,9 +358,9 @@ mod tests {
     }
 
     #[test]
-    fn test_language_is_luau_for_lua_extension() {
+    fn test_language_is_lua_for_lua_extension() {
         let source = b"local function greet()\nend";
         let symbols = parse_and_extract(source, "test.lua");
-        assert_eq!(symbols[0].language, Language::Luau);
+        assert_eq!(symbols[0].language, Language::Lua);
     }
 }

--- a/src/indexer/luau.rs
+++ b/src/indexer/luau.rs
@@ -1,0 +1,366 @@
+use std::sync::Arc;
+
+use tree_sitter::{Node, Tree};
+
+use crate::indexer::language::{make_symbol_id, Language, LanguageParser, Symbol, SymbolKind};
+
+pub struct LuauParser;
+
+impl LanguageParser for LuauParser {
+    fn language(&self) -> Language {
+        Language::Luau
+    }
+
+    fn extensions(&self) -> &[&str] {
+        &["luau", "lua"]
+    }
+
+    fn extract_symbols(&self, source: &[u8], tree: &Tree, path: &std::path::Path) -> Vec<Symbol> {
+        let mut symbols = Vec::new();
+        let root = tree.root_node();
+        let mut cursor = root.walk();
+        for child in root.children(&mut cursor) {
+            extract_from_node(source, child, path, &mut symbols);
+        }
+        symbols
+    }
+}
+
+fn node_text<'a>(source: &'a [u8], node: Node) -> &'a str {
+    node.utf8_text(source).unwrap_or("")
+}
+
+fn get_signature(source: &[u8], node: Node) -> Option<String> {
+    let text = node_text(source, node);
+    Some(text.lines().next()?.trim_end().to_string())
+}
+
+/// Walk backwards through preceding siblings collecting contiguous Luau comments.
+fn get_doc_comment(source: &[u8], node: Node) -> Option<String> {
+    let mut docs = Vec::new();
+    let mut prev = node.prev_sibling();
+    while let Some(p) = prev {
+        if p.kind() == "comment" {
+            docs.push(node_text(source, p).to_string());
+            prev = p.prev_sibling();
+            continue;
+        }
+        break;
+    }
+    if docs.is_empty() {
+        return None;
+    }
+    docs.reverse();
+    Some(docs.join("\n"))
+}
+
+fn push_symbol(
+    source: &[u8],
+    node: Node,
+    path: &std::path::Path,
+    name: String,
+    qualified: String,
+    kind: SymbolKind,
+    symbols: &mut Vec<Symbol>,
+) {
+    let id = make_symbol_id(path, &qualified, &kind);
+    let doc = get_doc_comment(source, node);
+    let signature = get_signature(source, node);
+    let start_pos = node.start_position();
+    let end_pos = node.end_position();
+    symbols.push(Symbol {
+        id,
+        name,
+        qualified,
+        kind,
+        language: Language::Luau,
+        file: Arc::new(path.to_path_buf()),
+        byte_start: node.start_byte(),
+        byte_end: node.end_byte(),
+        line_start: start_pos.row as u32 + 1,
+        line_end: end_pos.row as u32 + 1,
+        signature,
+        doc,
+    });
+}
+
+fn dotted_name(source: &[u8], node: Node) -> Option<String> {
+    match node.kind() {
+        "identifier" => Some(node_text(source, node).to_string()),
+        "dot_index_expression" => {
+            let table = dotted_name(source, node.child_by_field_name("table")?)?;
+            let field = node_text(source, node.child_by_field_name("field")?).to_string();
+            Some(format!("{table}.{field}"))
+        }
+        "field_type" => Some(node_text(source, node).to_string()),
+        "generic_type" => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if child.is_named() {
+                    return dotted_name(source, child);
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+fn function_name_parts(source: &[u8], node: Node) -> Option<(String, String, SymbolKind)> {
+    match node.kind() {
+        "identifier" => {
+            let name = node_text(source, node).to_string();
+            Some((name.clone(), name, SymbolKind::Function))
+        }
+        "dot_index_expression" => {
+            let qualified = dotted_name(source, node)?;
+            let name = node_text(source, node.child_by_field_name("field")?).to_string();
+            Some((name, qualified, SymbolKind::Method))
+        }
+        "method_index_expression" => {
+            let table = dotted_name(source, node.child_by_field_name("table")?)?;
+            let name = node_text(source, node.child_by_field_name("method")?).to_string();
+            Some((name.clone(), format!("{table}:{name}"), SymbolKind::Method))
+        }
+        _ => None,
+    }
+}
+
+fn type_alias_name(source: &[u8], node: Node) -> Option<String> {
+    match node.kind() {
+        "identifier" | "field_type" => Some(node_text(source, node).to_string()),
+        "generic_type" => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if child.is_named() {
+                    return type_alias_name(source, child);
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+fn variable_name_parts(source: &[u8], node: Node) -> Option<(String, String, SymbolKind)> {
+    match node.kind() {
+        "identifier" => {
+            let name = node_text(source, node).to_string();
+            Some((name.clone(), name, SymbolKind::Function))
+        }
+        "dot_index_expression" => {
+            let qualified = dotted_name(source, node)?;
+            let name = node_text(source, node.child_by_field_name("field")?).to_string();
+            Some((name, qualified, SymbolKind::Method))
+        }
+        _ => None,
+    }
+}
+
+fn assignment_lists(node: Node) -> Option<(Node, Node)> {
+    let mut variable_list = None;
+    let mut expression_list = None;
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "variable_list" => variable_list = Some(child),
+            "expression_list" => expression_list = Some(child),
+            _ => {}
+        }
+    }
+    Some((variable_list?, expression_list?))
+}
+
+fn assignment_targets(source: &[u8], node: Node) -> Vec<(String, String, SymbolKind)> {
+    let mut names = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if let Some(parts) = variable_name_parts(source, child) {
+            names.push(parts);
+        }
+    }
+    names
+}
+
+fn assignment_values(node: Node) -> Vec<Node> {
+    let mut values = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.is_named() {
+            values.push(child);
+        }
+    }
+    values
+}
+
+fn extract_function_assignments(
+    source: &[u8],
+    owner: Node,
+    assignment: Node,
+    path: &std::path::Path,
+    symbols: &mut Vec<Symbol>,
+) {
+    let Some((variables, expressions)) = assignment_lists(assignment) else {
+        return;
+    };
+
+    for ((name, qualified, kind), value) in assignment_targets(source, variables)
+        .into_iter()
+        .zip(assignment_values(expressions))
+    {
+        if value.kind() == "function_definition" {
+            push_symbol(source, owner, path, name, qualified, kind, symbols);
+        }
+    }
+}
+
+fn extract_from_node(source: &[u8], node: Node, path: &std::path::Path, symbols: &mut Vec<Symbol>) {
+    match node.kind() {
+        "function_declaration" => {
+            if let Some(name_node) = node.child_by_field_name("name") {
+                if let Some((name, qualified, kind)) = function_name_parts(source, name_node) {
+                    push_symbol(source, node, path, name, qualified, kind, symbols);
+                }
+            }
+        }
+        "type_definition" => {
+            if let Some(name_node) = node.child_by_field_name("name") {
+                if let Some(name) = type_alias_name(source, name_node) {
+                    push_symbol(
+                        source,
+                        node,
+                        path,
+                        name.clone(),
+                        name,
+                        SymbolKind::TypeAlias,
+                        symbols,
+                    );
+                }
+            }
+        }
+        "variable_declaration" => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if child.kind() == "assignment_statement" {
+                    extract_function_assignments(source, node, child, path, symbols);
+                }
+            }
+        }
+        "assignment_statement" => extract_function_assignments(source, node, node, path, symbols),
+        // Don't descend into function bodies.
+        "block" => {}
+        _ => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                extract_from_node(source, child, path, symbols);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::indexer::language::SymbolKind;
+    use std::path::Path;
+
+    fn parse_and_extract(source: &[u8], path: &str) -> Vec<Symbol> {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_luau::LANGUAGE.into())
+            .unwrap();
+        let tree = parser.parse(source, None).unwrap();
+        LuauParser.extract_symbols(source, &tree, Path::new(path))
+    }
+
+    #[test]
+    fn test_extract_local_function_declaration() {
+        let source = b"local function greet(name: string): string\n    return name\nend";
+        let symbols = parse_and_extract(source, "test.luau");
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name, "greet");
+        assert!(matches!(symbols[0].kind, SymbolKind::Function));
+    }
+
+    #[test]
+    fn test_extract_table_function_declaration() {
+        let source = b"function Greeter.new(name: string)\n    return { name = name }\nend";
+        let symbols = parse_and_extract(source, "test.luau");
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name, "new");
+        assert!(matches!(symbols[0].kind, SymbolKind::Method));
+        assert_eq!(symbols[0].qualified, "Greeter.new");
+    }
+
+    #[test]
+    fn test_extract_colon_method_declaration() {
+        let source = b"function Greeter:sayHello()\n    return self.name\nend";
+        let symbols = parse_and_extract(source, "test.luau");
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name, "sayHello");
+        assert!(matches!(symbols[0].kind, SymbolKind::Method));
+        assert_eq!(symbols[0].qualified, "Greeter:sayHello");
+    }
+
+    #[test]
+    fn test_extract_local_function_assignment() {
+        let source = b"local handler = function(player)\n    return player\nend";
+        let symbols = parse_and_extract(source, "test.luau");
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name, "handler");
+        assert!(matches!(symbols[0].kind, SymbolKind::Function));
+        let sig = symbols[0].signature.as_deref().unwrap_or("");
+        assert!(sig.starts_with("local handler = function("), "sig={sig}");
+    }
+
+    #[test]
+    fn test_extract_table_function_assignment() {
+        let source = b"Greeter.render = function(self)\n    return self.name\nend";
+        let symbols = parse_and_extract(source, "test.luau");
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name, "render");
+        assert!(matches!(symbols[0].kind, SymbolKind::Method));
+        assert_eq!(symbols[0].qualified, "Greeter.render");
+    }
+
+    #[test]
+    fn test_extract_exported_type_alias() {
+        let source = b"export type Point = { x: number, y: number }";
+        let symbols = parse_and_extract(source, "test.luau");
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name, "Point");
+        assert!(matches!(symbols[0].kind, SymbolKind::TypeAlias));
+    }
+
+    #[test]
+    fn test_extract_generic_type_alias_uses_base_name() {
+        let source = b"type Result<T> = { ok: boolean, value: T }";
+        let symbols = parse_and_extract(source, "test.luau");
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name, "Result");
+        assert!(matches!(symbols[0].kind, SymbolKind::TypeAlias));
+    }
+
+    #[test]
+    fn test_doc_comment_attached() {
+        let source = b"-- Greets the caller.\nlocal function greet()\nend";
+        let symbols = parse_and_extract(source, "test.luau");
+        let doc = symbols[0].doc.as_deref().unwrap_or("");
+        assert!(doc.contains("Greets the caller"), "doc={doc}");
+    }
+
+    #[test]
+    fn test_no_nested_functions() {
+        let source = b"local function outer()\n    local function inner()\n    end\nend";
+        let symbols = parse_and_extract(source, "test.luau");
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name, "outer");
+    }
+
+    #[test]
+    fn test_language_is_luau_for_lua_extension() {
+        let source = b"local function greet()\nend";
+        let symbols = parse_and_extract(source, "test.lua");
+        assert_eq!(symbols[0].language, Language::Luau);
+    }
+}

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -250,31 +250,9 @@ impl Indexer {
         let lang_parser = &self.parsers[parser_idx];
 
         let mut ts_parser = tree_sitter::Parser::new();
-        let ts_lang = match lang_parser.language() {
-            language::Language::Rust => tree_sitter_rust::LANGUAGE.into(),
-            language::Language::Python => tree_sitter_python::LANGUAGE.into(),
-            language::Language::JavaScript => tree_sitter_javascript::LANGUAGE.into(),
-            language::Language::TypeScript => {
-                let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-                if ext == "tsx" {
-                    tree_sitter_typescript::LANGUAGE_TSX.into()
-                } else {
-                    tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()
-                }
-            }
-            language::Language::C => tree_sitter_c::LANGUAGE.into(),
-            language::Language::Cpp => tree_sitter_cpp::LANGUAGE.into(),
-            language::Language::Go => tree_sitter_go::LANGUAGE.into(),
-            language::Language::Java => tree_sitter_java::LANGUAGE.into(),
-            language::Language::Bash => tree_sitter_bash::LANGUAGE.into(),
-            language::Language::CSharp => tree_sitter_c_sharp::LANGUAGE.into(),
-            language::Language::Ruby => tree_sitter_ruby::LANGUAGE.into(),
-            language::Language::Swift => tree_sitter_swift::LANGUAGE.into(),
-            language::Language::ObjC => tree_sitter_objc::LANGUAGE.into(),
-            language::Language::Php => tree_sitter_php::LANGUAGE_PHP.into(),
-            language::Language::Zig => tree_sitter_zig::LANGUAGE.into(),
-            language::Language::Kotlin => tree_sitter_kotlin_ng::LANGUAGE.into(),
-            language::Language::Luau => tree_sitter_luau::LANGUAGE.into(),
+        let ts_lang = match tree_sitter_language_for_extension(ext) {
+            Some(lang) => lang,
+            None => return Ok(vec![]),
         };
         ts_parser.set_language(&ts_lang)?;
 
@@ -408,6 +386,33 @@ pub fn is_supported_extension(ext: &str) -> bool {
             | "luau"
             | "lua"
     )
+}
+
+/// Returns the tree-sitter language for a supported extension.
+/// Keep this in sync with `is_supported_extension` so indexing and usage search
+/// agree on which parser to use for each file type.
+pub fn tree_sitter_language_for_extension(ext: &str) -> Option<tree_sitter::Language> {
+    Some(match ext {
+        "rs" => tree_sitter_rust::LANGUAGE.into(),
+        "py" => tree_sitter_python::LANGUAGE.into(),
+        "js" | "jsx" | "mjs" | "cjs" => tree_sitter_javascript::LANGUAGE.into(),
+        "ts" | "mts" | "cts" => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+        "tsx" => tree_sitter_typescript::LANGUAGE_TSX.into(),
+        "c" | "h" => tree_sitter_c::LANGUAGE.into(),
+        "cpp" | "cc" | "cxx" | "hpp" | "hxx" => tree_sitter_cpp::LANGUAGE.into(),
+        "go" => tree_sitter_go::LANGUAGE.into(),
+        "java" => tree_sitter_java::LANGUAGE.into(),
+        "sh" | "bash" => tree_sitter_bash::LANGUAGE.into(),
+        "cs" => tree_sitter_c_sharp::LANGUAGE.into(),
+        "rb" => tree_sitter_ruby::LANGUAGE.into(),
+        "swift" => tree_sitter_swift::LANGUAGE.into(),
+        "m" | "mm" => tree_sitter_objc::LANGUAGE.into(),
+        "php" => tree_sitter_php::LANGUAGE_PHP.into(),
+        "zig" => tree_sitter_zig::LANGUAGE.into(),
+        "kt" | "kts" => tree_sitter_kotlin_ng::LANGUAGE.into(),
+        "luau" | "lua" => tree_sitter_luau::LANGUAGE.into(),
+        _ => return None,
+    })
 }
 
 pub fn is_excluded_dir_name(name: &str) -> bool {

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -7,6 +7,7 @@ pub mod java;
 pub mod javascript;
 pub mod kotlin;
 pub mod language;
+pub mod luau;
 pub mod objc;
 pub mod php;
 pub mod python;
@@ -273,6 +274,7 @@ impl Indexer {
             language::Language::Php => tree_sitter_php::LANGUAGE_PHP.into(),
             language::Language::Zig => tree_sitter_zig::LANGUAGE.into(),
             language::Language::Kotlin => tree_sitter_kotlin_ng::LANGUAGE.into(),
+            language::Language::Luau => tree_sitter_luau::LANGUAGE.into(),
         };
         ts_parser.set_language(&ts_lang)?;
 
@@ -403,6 +405,8 @@ pub fn is_supported_extension(ext: &str) -> bool {
             | "zig"
             | "kt"
             | "kts"
+            | "luau"
+            | "lua"
     )
 }
 
@@ -514,6 +518,43 @@ mod tests {
 
         assert_eq!(file_count, 1);
         assert_eq!(index.symbol_count(), 2);
+    }
+
+    #[test]
+    fn test_index_project_luau_file() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("init.luau"),
+            b"local function greet()\nend\nexport type Point = { x: number, y: number }\n",
+        )
+        .unwrap();
+
+        let (index, file_count) = create_indexer().index_project(dir.path(), &[]).unwrap();
+
+        assert_eq!(file_count, 1);
+        let names: Vec<_> = index.symbols.values().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"greet"));
+        assert!(names.contains(&"Point"));
+    }
+
+    #[test]
+    fn test_index_project_lua_extension_uses_luau_parser() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("module.lua"),
+            b"function Greeter:speak()\nend\n",
+        )
+        .unwrap();
+
+        let (index, file_count) = create_indexer().index_project(dir.path(), &[]).unwrap();
+
+        assert_eq!(file_count, 1);
+        let method = index
+            .symbols
+            .values()
+            .find(|s| s.name == "speak")
+            .expect("Luau method should be indexed");
+        assert_eq!(method.language, language::Language::Luau);
     }
 
     #[test]

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -7,7 +7,7 @@ pub mod java;
 pub mod javascript;
 pub mod kotlin;
 pub mod language;
-pub mod luau;
+pub mod lua;
 pub mod objc;
 pub mod php;
 pub mod python;
@@ -558,8 +558,8 @@ mod tests {
             .symbols
             .values()
             .find(|s| s.name == "speak")
-            .expect("Luau method should be indexed");
-        assert_eq!(method.language, language::Language::Luau);
+            .expect("Lua method should be indexed");
+        assert_eq!(method.language, language::Language::Lua);
     }
 
     #[test]

--- a/src/indexer/registry.rs
+++ b/src/indexer/registry.rs
@@ -7,7 +7,7 @@ use crate::indexer::java::JavaParser;
 use crate::indexer::javascript::JavaScriptParser;
 use crate::indexer::kotlin::KotlinParser;
 use crate::indexer::language::LanguageParser;
-use crate::indexer::luau::LuauParser;
+use crate::indexer::lua::LuaParser;
 use crate::indexer::objc::ObjCParser;
 use crate::indexer::php::PhpParser;
 use crate::indexer::python::PythonParser;
@@ -35,6 +35,6 @@ pub fn build_default_registry() -> Vec<Box<dyn LanguageParser>> {
         Box::new(PhpParser),
         Box::new(ZigParser),
         Box::new(KotlinParser),
-        Box::new(LuauParser),
+        Box::new(LuaParser),
     ]
 }

--- a/src/indexer/registry.rs
+++ b/src/indexer/registry.rs
@@ -7,6 +7,7 @@ use crate::indexer::java::JavaParser;
 use crate::indexer::javascript::JavaScriptParser;
 use crate::indexer::kotlin::KotlinParser;
 use crate::indexer::language::LanguageParser;
+use crate::indexer::luau::LuauParser;
 use crate::indexer::objc::ObjCParser;
 use crate::indexer::php::PhpParser;
 use crate::indexer::python::PythonParser;
@@ -34,5 +35,6 @@ pub fn build_default_registry() -> Vec<Box<dyn LanguageParser>> {
         Box::new(PhpParser),
         Box::new(ZigParser),
         Box::new(KotlinParser),
+        Box::new(LuauParser),
     ]
 }

--- a/src/tools/find_usages.rs
+++ b/src/tools/find_usages.rs
@@ -559,9 +559,13 @@ mod tests {
         .await
         .unwrap();
 
-        let usages = response["usages"].as_array().expect("usages must be an array");
+        let usages = response["usages"]
+            .as_array()
+            .expect("usages must be an array");
         assert!(
-            usages.iter().any(|usage| usage["file"] == "RotateTool.luau"),
+            usages
+                .iter()
+                .any(|usage| usage["file"] == "RotateTool.luau"),
             "expected definition hit in RotateTool.luau, got: {usages:?}"
         );
         assert!(

--- a/src/tools/find_usages.rs
+++ b/src/tools/find_usages.rs
@@ -6,7 +6,7 @@ use serde_json::{json, Value};
 use walkdir::WalkDir;
 
 use crate::error::ToolError;
-use crate::indexer::is_supported_extension;
+use crate::indexer::{is_supported_extension, tree_sitter_language_for_extension};
 use crate::tools::index_project::load_project_index;
 
 pub struct FindUsagesParams {
@@ -118,16 +118,9 @@ pub async fn find_usages(params: FindUsagesParams) -> anyhow::Result<Value> {
 fn search_file_ast(path: &Path, name: &str) -> anyhow::Result<Vec<(usize, usize, String)>> {
     let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
 
-    let ts_lang: tree_sitter::Language = match ext {
-        "rs" => tree_sitter_rust::LANGUAGE.into(),
-        "py" => tree_sitter_python::LANGUAGE.into(),
-        "js" | "jsx" | "mjs" | "cjs" => tree_sitter_javascript::LANGUAGE.into(),
-        "ts" | "mts" | "cts" => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
-        "tsx" => tree_sitter_typescript::LANGUAGE_TSX.into(),
-        "c" | "h" => tree_sitter_c::LANGUAGE.into(),
-        "cpp" | "cc" | "cxx" | "hpp" | "hxx" => tree_sitter_cpp::LANGUAGE.into(),
-        "kt" | "kts" => tree_sitter_kotlin_ng::LANGUAGE.into(),
-        _ => return Ok(vec![]),
+    let ts_lang = match tree_sitter_language_for_extension(ext) {
+        Some(lang) => lang,
+        None => return Ok(vec![]),
     };
 
     // Skip oversized files (same guard as the indexer)
@@ -506,6 +499,77 @@ mod tests {
         );
         let hits = search_file_ast(&path, "Greeter").unwrap();
         assert!(hits.is_empty(), "comment mention must not be returned");
+    }
+
+    // ── Luau ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_luau_finds_definition_and_call() {
+        let dir = TempDir::new().unwrap();
+        let path = write(
+            &dir,
+            "RotateTool.luau",
+            "local function SetRotation(cf: CFrame)\n    return cf\nend\n\nSetRotation(CFrame.new())\n",
+        );
+        let hits = search_file_ast(&path, "SetRotation").unwrap();
+        let lines: Vec<usize> = hits.iter().map(|(l, _, _)| *l).collect();
+        assert!(lines.contains(&1), "definition on line 1");
+        assert!(lines.contains(&5), "call on line 5");
+    }
+
+    #[tokio::test]
+    async fn test_find_usages_luau_finds_cross_file_call_sites() {
+        use crate::index::format::{index_dir, save_index};
+        use crate::indexer::{registry, Indexer};
+
+        let dir = TempDir::new().unwrap();
+        write(
+            &dir,
+            "RotateTool.luau",
+            "local RotateTool = {}\n\nfunction RotateTool.SetRotation(cf: CFrame)\n    return cf\nend\n\nreturn RotateTool\n",
+        );
+        write(
+            &dir,
+            "Main.server.luau",
+            "local RotateTool = require(script.Parent.RotateTool)\n\nRotateTool.SetRotation(CFrame.new())\n",
+        );
+
+        let indexer = Indexer::new(registry::build_default_registry());
+        let (index, _) = indexer.index_project(dir.path(), &[]).unwrap();
+        let canonical = dir.path().canonicalize().unwrap();
+        let idx_dir = index_dir(&canonical).unwrap();
+        std::fs::create_dir_all(&idx_dir).unwrap();
+        save_index(&index, &idx_dir.join("index.bin")).unwrap();
+        let project = dir.path().to_string_lossy().to_string();
+
+        let sym_id = index
+            .symbols
+            .values()
+            .find(|s| s.name == "SetRotation")
+            .map(|s| s.id.clone())
+            .expect("SetRotation must be indexed");
+
+        let response = find_usages(FindUsagesParams {
+            project,
+            symbol_id: sym_id,
+            scope: None,
+            limit: None,
+            offset: None,
+        })
+        .await
+        .unwrap();
+
+        let usages = response["usages"].as_array().expect("usages must be an array");
+        assert!(
+            usages.iter().any(|usage| usage["file"] == "RotateTool.luau"),
+            "expected definition hit in RotateTool.luau, got: {usages:?}"
+        );
+        assert!(
+            usages
+                .iter()
+                .any(|usage| usage["file"] == "Main.server.luau"),
+            "expected cross-file call hit in Main.server.luau, got: {usages:?}"
+        );
     }
 
     // ── Early-exit across multiple files ────────────────────────────────────

--- a/src/tools/search_symbols.rs
+++ b/src/tools/search_symbols.rs
@@ -79,11 +79,11 @@ pub async fn search_symbols(params: SearchSymbolsParams) -> anyhow::Result<Value
             "kotlin" | "kt" => Ok(Language::Kotlin),
             "php" => Ok(Language::Php),
             "zig" => Ok(Language::Zig),
-            "luau" | "lua" => Ok(Language::Luau),
+            "luau" | "lua" => Ok(Language::Lua),
             other => Err(ToolError::InvalidArgument {
                 param: "language".to_string(),
                 message: format!(
-                    "Unknown language '{}'. Supported: rust, python, javascript, typescript, c, cpp, go, java, bash, csharp, ruby, swift, objc, php, zig, kotlin, luau",
+                    "Unknown language '{}'. Supported: rust, python, javascript, typescript, c, cpp, go, java, bash, csharp, ruby, swift, objc, php, zig, kotlin, lua",
                     other
                 ),
             }),
@@ -315,6 +315,58 @@ mod tests {
         assert_eq!(tool_err.code(), "INVALID_ARGUMENT");
         assert!(tool_err.to_string().contains("kind"));
         assert!(tool_err.to_string().contains("widget"));
+    }
+
+    #[tokio::test]
+    async fn test_language_filter_lua_matches_luau_files() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("RotateTool.luau"),
+            b"local function SetRotation()\nend\n",
+        )
+        .unwrap();
+        let project = setup_project(&dir).await;
+
+        let response = search_symbols(SearchSymbolsParams {
+            project,
+            query: "SetRotation".to_string(),
+            kind: None,
+            language: Some("lua".to_string()),
+            file: None,
+            limit: None,
+            offset: None,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(response["count"], 1);
+        assert_eq!(response["results"][0]["language"], "lua");
+    }
+
+    #[tokio::test]
+    async fn test_language_filter_luau_alias_maps_to_lua() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("RotateTool.luau"),
+            b"local function SetRotation()\nend\n",
+        )
+        .unwrap();
+        let project = setup_project(&dir).await;
+
+        let response = search_symbols(SearchSymbolsParams {
+            project,
+            query: "SetRotation".to_string(),
+            kind: None,
+            language: Some("luau".to_string()),
+            file: None,
+            limit: None,
+            offset: None,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(response["count"], 1);
+        assert_eq!(response["results"][0]["language"], "lua");
     }
 
     #[tokio::test]

--- a/src/tools/search_symbols.rs
+++ b/src/tools/search_symbols.rs
@@ -77,10 +77,13 @@ pub async fn search_symbols(params: SearchSymbolsParams) -> anyhow::Result<Value
             "swift" => Ok(Language::Swift),
             "objc" | "objective-c" | "objectivec" => Ok(Language::ObjC),
             "kotlin" | "kt" => Ok(Language::Kotlin),
+            "php" => Ok(Language::Php),
+            "zig" => Ok(Language::Zig),
+            "luau" | "lua" => Ok(Language::Luau),
             other => Err(ToolError::InvalidArgument {
                 param: "language".to_string(),
                 message: format!(
-                    "Unknown language '{}'. Supported: rust, python, javascript, typescript, c, cpp, go, java, bash, csharp, ruby, swift, objc, kotlin",
+                    "Unknown language '{}'. Supported: rust, python, javascript, typescript, c, cpp, go, java, bash, csharp, ruby, swift, objc, php, zig, kotlin, luau",
                     other
                 ),
             }),


### PR DESCRIPTION
## Summary
- add `tree-sitter-luau` and wire Luau into the language registry and extension handling
- index Luau and Roblox-style `.luau`/`.lua` functions, methods, anonymous function assignments, and type aliases
- update search language filters and repository docs for the new language support

## Why
Luau is a common target for Roblox codebases, but the indexer could not previously parse or search those projects.

## Verification
- `cargo test --verbose`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
