### PR TITLE
Add .svelte source-format support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2044,6 +2044,7 @@ dependencies = [
  "tree-sitter-python",
  "tree-sitter-ruby",
  "tree-sitter-rust",
+ "tree-sitter-svelte-ng",
  "tree-sitter-swift",
  "tree-sitter-typescript",
  "tree-sitter-zig",
@@ -3490,6 +3491,16 @@ name = "tree-sitter-rust"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-svelte-ng"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef0a71f9cf5e94373cc86c64893630c8a29bb25d3390a248268d08af2165fa37"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ tree-sitter-php = "0.24"
 tree-sitter-zig = "1.1.2"
 tree-sitter-kotlin-ng = "1.1.0"
 tree-sitter-luau = "1.2.0"
+tree-sitter-svelte-ng = "1.0.2"
 tantivy = "0.22"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 futures = "0.3"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ AI coding agents default to reading whole files. With pitlane-mcp, they fetch on
 
 ## Features
 
-- **AST-based indexing** — tree-sitter parses Rust, Python, JavaScript, TypeScript, C, C++, Go, Java, C#, Ruby, Swift, Objective-C, PHP, Zig, Kotlin, Lua, and Bash source into structured symbols
+- **AST-based indexing** — tree-sitter parses Rust, Python, JavaScript, TypeScript, Svelte, C, C++, Go, Java, C#, Ruby, Swift, Objective-C, PHP, Zig, Kotlin, Lua, and Bash source into structured symbols
 - **BM25 full-text search** — tantivy-backed ranked search over name, qualified name, signature, and doc fields with a custom camelCase tokenizer (`LowerInstruction` → `["lower", "instruction"]`); falls back to exact substring match if the index isn't ready
 - **Ten MCP tools** for navigation: outline, search, fetch, line-range fetch, find usages, index stats, usage stats
 - **Incremental re-indexing** — background watcher re-parses only changed files
@@ -26,6 +26,7 @@ AI coding agents default to reading whole files. With pitlane-mcp, they fetch on
 | Python | `.py` | function, method, class |
 | JavaScript | `.js`, `.jsx`, `.mjs`, `.cjs` | function, class, method |
 | TypeScript | `.ts`, `.tsx`, `.mts`, `.cts` | function, class, method, interface, type alias, enum |
+| Svelte | `.svelte` | function, class, method, interface, type alias, enum (from embedded `<script>` blocks) |
 | C | `.c`, `.h` | function, struct, enum, type alias, macro |
 | C++ | `.cpp`, `.cc`, `.cxx`, `.hpp`, `.hxx` | function, method, class, struct, enum, type alias, macro |
 | Go | `.go` | function, method, struct, interface, type alias |

--- a/src/embed/client.rs
+++ b/src/embed/client.rs
@@ -469,7 +469,7 @@ mod tests {
                 "mod", "macro", "const", "type_alias", "class", "interface",
             ];
             let langs = [
-                "rust", "python", "javascript", "typescript", "c", "cpp",
+                "rust", "python", "javascript", "typescript", "svelte", "c", "cpp",
                 "go", "java", "bash", "csharp", "ruby", "swift",
                 "objc", "php", "zig", "kotlin", "lua",
             ];

--- a/src/indexer/language.rs
+++ b/src/indexer/language.rs
@@ -10,6 +10,7 @@ pub enum Language {
     Python,
     JavaScript,
     TypeScript,
+    Svelte,
     C,
     Cpp,
     Go,
@@ -32,6 +33,7 @@ impl std::fmt::Display for Language {
             Language::Python => write!(f, "python"),
             Language::JavaScript => write!(f, "javascript"),
             Language::TypeScript => write!(f, "typescript"),
+            Language::Svelte => write!(f, "svelte"),
             Language::C => write!(f, "c"),
             Language::Cpp => write!(f, "cpp"),
             Language::Go => write!(f, "go"),
@@ -158,6 +160,7 @@ mod tests {
     fn test_language_display() {
         assert_eq!(Language::Rust.to_string(), "rust");
         assert_eq!(Language::Python.to_string(), "python");
+        assert_eq!(Language::Svelte.to_string(), "svelte");
         assert_eq!(Language::C.to_string(), "c");
         assert_eq!(Language::Cpp.to_string(), "cpp");
         assert_eq!(Language::Kotlin.to_string(), "kotlin");

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -14,6 +14,7 @@ pub mod python;
 pub mod registry;
 pub mod ruby;
 pub mod rust;
+pub mod svelte;
 pub mod swift;
 pub mod typescript;
 pub mod zig;
@@ -382,6 +383,7 @@ pub fn is_supported_extension(ext: &str) -> bool {
             | "tsx"
             | "mts"
             | "cts"
+            | "svelte"
             | "c"
             | "h"
             | "cpp"
@@ -417,6 +419,7 @@ pub fn tree_sitter_language_for_extension(ext: &str) -> Option<tree_sitter::Lang
         "js" | "jsx" | "mjs" | "cjs" => tree_sitter_javascript::LANGUAGE.into(),
         "ts" | "mts" | "cts" => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
         "tsx" => tree_sitter_typescript::LANGUAGE_TSX.into(),
+        "svelte" => tree_sitter_svelte_ng::LANGUAGE.into(),
         "c" | "h" => tree_sitter_c::LANGUAGE.into(),
         "cpp" | "cc" | "cxx" | "hpp" | "hxx" => tree_sitter_cpp::LANGUAGE.into(),
         "go" => tree_sitter_go::LANGUAGE.into(),

--- a/src/indexer/registry.rs
+++ b/src/indexer/registry.rs
@@ -13,6 +13,7 @@ use crate::indexer::php::PhpParser;
 use crate::indexer::python::PythonParser;
 use crate::indexer::ruby::RubyParser;
 use crate::indexer::rust::RustParser;
+use crate::indexer::svelte::SvelteParser;
 use crate::indexer::swift::SwiftParser;
 use crate::indexer::typescript::TypeScriptParser;
 use crate::indexer::zig::ZigParser;
@@ -23,6 +24,7 @@ pub fn build_default_registry() -> Vec<Box<dyn LanguageParser>> {
         Box::new(PythonParser),
         Box::new(JavaScriptParser),
         Box::new(TypeScriptParser),
+        Box::new(SvelteParser),
         Box::new(CParser),
         Box::new(CppParser),
         Box::new(GoParser),

--- a/src/indexer/svelte.rs
+++ b/src/indexer/svelte.rs
@@ -1,0 +1,249 @@
+use std::sync::Arc;
+
+use tree_sitter::{Node, Tree};
+
+use crate::indexer::javascript::JavaScriptParser;
+use crate::indexer::language::{make_symbol_id, Language, LanguageParser, Symbol};
+use crate::indexer::typescript::TypeScriptParser;
+
+pub struct SvelteParser;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ScriptBlockLanguage {
+    JavaScript,
+    TypeScript,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ScriptBlock {
+    pub byte_start: usize,
+    pub byte_end: usize,
+    pub line_start: u32,
+    pub language: ScriptBlockLanguage,
+}
+
+impl LanguageParser for SvelteParser {
+    fn language(&self) -> Language {
+        Language::Svelte
+    }
+
+    fn extensions(&self) -> &[&str] {
+        &["svelte"]
+    }
+
+    fn extract_symbols(&self, source: &[u8], tree: &Tree, path: &std::path::Path) -> Vec<Symbol> {
+        let mut symbols = Vec::new();
+
+        for block in collect_script_blocks(source, tree.root_node()) {
+            let script_source = &source[block.byte_start..block.byte_end];
+            let mut parser = tree_sitter::Parser::new();
+            let language = match block.language {
+                ScriptBlockLanguage::JavaScript => tree_sitter_javascript::LANGUAGE.into(),
+                ScriptBlockLanguage::TypeScript => {
+                    tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()
+                }
+            };
+
+            if parser.set_language(&language).is_err() {
+                continue;
+            }
+
+            let Some(tree) = parser.parse(script_source, None) else {
+                continue;
+            };
+
+            let mut extracted = match block.language {
+                ScriptBlockLanguage::JavaScript => {
+                    JavaScriptParser.extract_symbols(script_source, &tree, path)
+                }
+                ScriptBlockLanguage::TypeScript => {
+                    TypeScriptParser.extract_symbols(script_source, &tree, path)
+                }
+            };
+
+            for symbol in &mut extracted {
+                symbol.id = make_symbol_id(path, &symbol.qualified, &symbol.kind);
+                symbol.language = Language::Svelte;
+                symbol.file = Arc::new(path.to_path_buf());
+                symbol.byte_start += block.byte_start;
+                symbol.byte_end += block.byte_start;
+                symbol.line_start += block.line_start - 1;
+                symbol.line_end += block.line_start - 1;
+            }
+
+            symbols.extend(extracted);
+        }
+
+        symbols
+    }
+}
+
+fn node_text<'a>(source: &'a [u8], node: Node) -> &'a str {
+    node.utf8_text(source).unwrap_or("")
+}
+
+fn parse_lang_attr(value: &str) -> ScriptBlockLanguage {
+    match value
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "ts" | "typescript" | "text/typescript" => ScriptBlockLanguage::TypeScript,
+        _ => ScriptBlockLanguage::JavaScript,
+    }
+}
+
+fn script_block_language(source: &[u8], script_element: Node) -> ScriptBlockLanguage {
+    let mut cursor = script_element.walk();
+    for child in script_element.children(&mut cursor) {
+        if child.kind() != "start_tag" {
+            continue;
+        }
+
+        let mut tag_cursor = child.walk();
+        for attr in child.children(&mut tag_cursor) {
+            if attr.kind() != "attribute" {
+                continue;
+            }
+
+            let text = node_text(source, attr);
+            if let Some((name, value)) = text.split_once('=') {
+                if name.trim().eq_ignore_ascii_case("lang") {
+                    return parse_lang_attr(value);
+                }
+            }
+        }
+    }
+
+    ScriptBlockLanguage::JavaScript
+}
+
+pub(crate) fn collect_script_blocks(source: &[u8], root: Node) -> Vec<ScriptBlock> {
+    let mut blocks = Vec::new();
+    collect_script_blocks_from_node(source, root, &mut blocks);
+    blocks
+}
+
+fn collect_script_blocks_from_node(source: &[u8], node: Node, blocks: &mut Vec<ScriptBlock>) {
+    if node.kind() == "script_element" {
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if child.kind() == "raw_text" {
+                blocks.push(ScriptBlock {
+                    byte_start: child.start_byte(),
+                    byte_end: child.end_byte(),
+                    line_start: child.start_position().row as u32 + 1,
+                    language: script_block_language(source, node),
+                });
+                break;
+            }
+        }
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_script_blocks_from_node(source, child, blocks);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::indexer::language::SymbolKind;
+    use std::path::Path;
+
+    fn parse_and_extract(path: &str, source: &[u8]) -> Vec<Symbol> {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_svelte_ng::LANGUAGE.into())
+            .unwrap();
+        let tree = parser.parse(source, None).unwrap();
+        SvelteParser.extract_symbols(source, &tree, Path::new(path))
+    }
+
+    #[test]
+    fn test_extracts_javascript_symbols_from_script_block() {
+        let source = br#"<script>
+function greet() {}
+class Greeter {
+  wave() {}
+}
+</script>
+
+<div>{greet()}</div>
+"#;
+
+        let symbols = parse_and_extract("Component.svelte", source);
+        let names: Vec<_> = symbols.iter().map(|s| s.name.as_str()).collect();
+
+        assert!(names.contains(&"greet"));
+        assert!(names.contains(&"Greeter"));
+        assert!(names.contains(&"wave"));
+        assert!(symbols.iter().all(|s| s.language == Language::Svelte));
+    }
+
+    #[test]
+    fn test_extracts_typescript_symbols_from_lang_ts_script_block() {
+        let source = br#"<script lang='ts'>
+export interface Props { id: string; }
+export type Status = 'draft' | 'published';
+export enum Mode { View }
+</script>
+"#;
+
+        let symbols = parse_and_extract("Component.svelte", source);
+        assert!(symbols
+            .iter()
+            .any(|s| s.name == "Props" && s.kind == SymbolKind::Interface));
+        assert!(symbols
+            .iter()
+            .any(|s| s.name == "Status" && s.kind == SymbolKind::TypeAlias));
+        assert!(symbols
+            .iter()
+            .any(|s| s.name == "Mode" && s.kind == SymbolKind::Enum));
+    }
+
+    #[test]
+    fn test_maps_symbol_offsets_back_to_original_svelte_file() {
+        let source = br#"<script>
+function greet() {}
+</script>
+<div />
+"#;
+
+        let symbols = parse_and_extract("Component.svelte", source);
+        let greet = symbols.iter().find(|s| s.name == "greet").unwrap();
+
+        assert_eq!(greet.line_start, 2);
+        assert_eq!(greet.line_end, 2);
+        assert_eq!(
+            &source[greet.byte_start..greet.byte_end],
+            b"function greet() {}"
+        );
+    }
+
+    #[test]
+    fn test_extracts_symbols_from_multiple_script_blocks() {
+        let source = br#"<script context='module' lang='ts'>
+export interface LoaderData { slug: string; }
+</script>
+
+<script>
+function hydrate() {}
+</script>
+"#;
+
+        let symbols = parse_and_extract("Component.svelte", source);
+        assert!(symbols.iter().any(|s| s.name == "LoaderData"));
+        assert!(symbols.iter().any(|s| s.name == "hydrate"));
+    }
+
+    #[test]
+    fn test_language_is_svelte() {
+        let source = br#"<script>function f() {}</script>"#;
+        let symbols = parse_and_extract("Component.svelte", source);
+        assert_eq!(symbols[0].language, Language::Svelte);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ pub struct SearchSymbolsRequest {
     pub query: String,
     /// Filter by SymbolKind (e.g. "method", "trait")
     pub kind: Option<String>,
-    /// Filter by language ("rust", "python", "javascript", "typescript", "c", "cpp", "go", "java", "bash", "csharp")
+    /// Filter by language ("rust", "python", "javascript", "typescript", "svelte", "c", "cpp", "go", "java", "bash", "csharp")
     pub language: Option<String>,
     /// Glob pattern to restrict search to specific files
     pub file: Option<String>,

--- a/src/tools/find_usages.rs
+++ b/src/tools/find_usages.rs
@@ -6,6 +6,7 @@ use serde_json::{json, Value};
 use walkdir::WalkDir;
 
 use crate::error::ToolError;
+use crate::indexer::svelte::{collect_script_blocks, ScriptBlockLanguage};
 use crate::indexer::{is_supported_extension, tree_sitter_language_for_extension};
 use crate::tools::index_project::load_project_index;
 
@@ -118,11 +119,6 @@ pub async fn find_usages(params: FindUsagesParams) -> anyhow::Result<Value> {
 fn search_file_ast(path: &Path, name: &str) -> anyhow::Result<Vec<(usize, usize, String)>> {
     let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
 
-    let ts_lang = match tree_sitter_language_for_extension(ext) {
-        Some(lang) => lang,
-        None => return Ok(vec![]),
-    };
-
     // Skip oversized files (same guard as the indexer)
     if path.metadata().map(|m| m.len()).unwrap_or(0) > 1024 * 1024 {
         return Ok(vec![]);
@@ -140,6 +136,15 @@ fn search_file_ast(path: &Path, name: &str) -> anyhow::Result<Vec<(usize, usize,
     }
 
     let lines: Vec<&str> = source_str.lines().collect();
+
+    if ext == "svelte" {
+        return search_svelte_file_ast(&source, &lines, name);
+    }
+
+    let ts_lang = match tree_sitter_language_for_extension(ext) {
+        Some(lang) => lang,
+        None => return Ok(vec![]),
+    };
 
     let mut parser = tree_sitter::Parser::new();
     parser.set_language(&ts_lang)?;
@@ -163,6 +168,54 @@ fn search_file_ast(path: &Path, name: &str) -> anyhow::Result<Vec<(usize, usize,
 
     hits.sort_unstable();
 
+    Ok(hits)
+}
+
+fn search_svelte_file_ast(
+    source: &[u8],
+    lines: &[&str],
+    name: &str,
+) -> anyhow::Result<Vec<(usize, usize, String)>> {
+    let mut parser = tree_sitter::Parser::new();
+    parser.set_language(&tree_sitter_svelte_ng::LANGUAGE.into())?;
+
+    let Some(tree) = parser.parse(source, None) else {
+        return Ok(vec![]);
+    };
+
+    let mut hits = Vec::new();
+    let mut seen = HashSet::new();
+
+    for block in collect_script_blocks(source, tree.root_node()) {
+        let script_source = &source[block.byte_start..block.byte_end];
+        let script_str = std::str::from_utf8(script_source).unwrap_or("");
+        if !script_str.contains(name) {
+            continue;
+        }
+
+        let ts_lang = match block.language {
+            ScriptBlockLanguage::JavaScript => tree_sitter_javascript::LANGUAGE.into(),
+            ScriptBlockLanguage::TypeScript => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+        };
+
+        let mut script_parser = tree_sitter::Parser::new();
+        script_parser.set_language(&ts_lang)?;
+        let Some(script_tree) = script_parser.parse(script_source, None) else {
+            continue;
+        };
+
+        collect_identifier_nodes_embedded(
+            script_tree.root_node(),
+            script_source,
+            name,
+            lines,
+            block.line_start as usize - 1,
+            &mut hits,
+            &mut seen,
+        );
+    }
+
+    hits.sort_unstable();
     Ok(hits)
 }
 
@@ -196,6 +249,37 @@ fn collect_identifier_nodes(
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         collect_identifier_nodes(child, source, name, lines, hits, seen);
+    }
+}
+
+fn collect_identifier_nodes_embedded(
+    node: tree_sitter::Node<'_>,
+    source: &[u8],
+    name: &str,
+    lines: &[&str],
+    row_offset: usize,
+    hits: &mut Vec<(usize, usize, String)>,
+    seen: &mut HashSet<(usize, usize)>,
+) {
+    if matches!(
+        node.kind(),
+        "identifier" | "type_identifier" | "field_identifier"
+    ) && node.utf8_text(source).ok() == Some(name)
+    {
+        let row = row_offset + node.start_position().row;
+        let col = node.start_position().column;
+        if seen.insert((row, col)) {
+            let snippet = lines
+                .get(row)
+                .map(|l| l.trim().to_string())
+                .unwrap_or_default();
+            hits.push((row + 1, col + 1, snippet));
+        }
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_identifier_nodes_embedded(child, source, name, lines, row_offset, hits, seen);
     }
 }
 
@@ -515,6 +599,24 @@ mod tests {
         let lines: Vec<usize> = hits.iter().map(|(l, _, _)| *l).collect();
         assert!(lines.contains(&1), "definition on line 1");
         assert!(lines.contains(&5), "call on line 5");
+    }
+
+    #[test]
+    fn test_svelte_finds_definition_and_call_in_script_block() {
+        let dir = TempDir::new().unwrap();
+        let path = write(
+            &dir,
+            "Component.svelte",
+            "<script>
+function greet() {}
+greet()
+</script>
+<div>{greet()}</div>
+",
+        );
+        let hits = search_file_ast(&path, "greet").unwrap();
+        let lines: Vec<usize> = hits.iter().map(|(l, _, _)| *l).collect();
+        assert_eq!(lines, vec![2, 3]);
     }
 
     #[tokio::test]

--- a/src/tools/search_symbols.rs
+++ b/src/tools/search_symbols.rs
@@ -79,6 +79,7 @@ pub async fn search_symbols(params: SearchSymbolsParams) -> anyhow::Result<Value
             "python" => Ok(Language::Python),
             "javascript" | "js" => Ok(Language::JavaScript),
             "typescript" | "ts" => Ok(Language::TypeScript),
+            "svelte" => Ok(Language::Svelte),
             "c" => Ok(Language::C),
             "cpp" | "c++" => Ok(Language::Cpp),
             "go" => Ok(Language::Go),
@@ -95,7 +96,7 @@ pub async fn search_symbols(params: SearchSymbolsParams) -> anyhow::Result<Value
             other => Err(ToolError::InvalidArgument {
                 param: "language".to_string(),
                 message: format!(
-                    "Unknown language '{}'. Supported: rust, python, javascript, typescript, c, cpp, go, java, bash, csharp, ruby, swift, objc, php, zig, kotlin, lua",
+                    "Unknown language '{}'. Supported: rust, python, javascript, typescript, svelte, c, cpp, go, java, bash, csharp, ruby, swift, objc, php, zig, kotlin, lua",
                     other
                 ),
             }),


### PR DESCRIPTION
## Summary

Treat `.svelte` as a supported source format and extract generic symbols from embedded `<script>` / `<script lang="ts">` blocks.

This keeps the implementation within the narrower scope discussed in #13:
- no SvelteKit-specific behavior
- no framework-aware semantics
- no special handling for runes/template/style sections

## What changed

- added `Language::Svelte` and `.svelte` extension support
- added `src/indexer/svelte.rs` using `tree-sitter-svelte-ng`
- parse embedded script blocks as JavaScript or TypeScript based on `lang`
- remap extracted symbol byte/line ranges back to the original `.svelte` file
- added `svelte` support to language filtering in `search_symbols`
- added `find_usages` support for identifiers inside embedded script blocks
- updated README supported languages/docs

## Notes

This intentionally limits support to generic symbol extraction from script content. Template/style-specific semantics are left out on purpose.

## Validation

- `cargo fmt`
- `cargo test`

Closes #13
