### PR TITLE
add MCP info for cursor to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,19 @@ Add to `.vscode/mcp.json` or `.kiro/settings/mcp.json`:
 }
 ```
 
+### Cursor
+
+```json
+{
+  "mcpServers": {
+    "pitlane-mcp": {
+      "command": "pitlane-mcp",
+      "args": []
+    }
+  }
+}
+```
+
 ## Default Workflow
 
 Most users should stay on the default tool tier:


### PR DESCRIPTION
Adds information to readme for setting up cursor MCP. It's a bit redundant but cursor is quite popular amongst the vibe coders who will probably be using this.