### PR TITLE
Add PITLANE_EXCLUDE_DIRS process override

### DIFF
--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -20,7 +20,7 @@ pub mod swift;
 pub mod typescript;
 pub mod zig;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -34,6 +34,7 @@ use language::LanguageParser;
 
 /// Files larger than this are skipped to avoid memory exhaustion and parser hangs.
 const MAX_FILE_BYTES: u64 = 1024 * 1024; // 1 MiB
+pub const EXCLUDE_DIRS_ENV_VAR: &str = "PITLANE_EXCLUDE_DIRS";
 
 pub struct Indexer {
     parsers: Vec<Box<dyn LanguageParser>>,
@@ -87,6 +88,7 @@ impl Indexer {
         on_progress: Option<&(dyn Fn(usize, usize) + Send + Sync)>,
     ) -> anyhow::Result<(SymbolIndex, usize)> {
         let exclude_set = Self::build_exclude_set(exclude_patterns)?;
+        let extra_excluded_dirs = extra_excluded_dir_names();
 
         // Phase 1 — collect eligible file paths (sequential: WalkDir is not parallel).
         let eligible: Vec<std::path::PathBuf> = WalkDir::new(root)
@@ -109,10 +111,11 @@ impl Indexer {
                     if exclude_set.is_match(format!("{}/", rel_str).as_str()) {
                         return false;
                     }
-                    if rel
-                        .components()
-                        .any(|c| c.as_os_str().to_str().is_some_and(is_excluded_dir_name))
-                    {
+                    if rel.components().any(|c| {
+                        c.as_os_str().to_str().is_some_and(|name| {
+                            is_excluded_dir_name_with_custom(name, &extra_excluded_dirs)
+                        })
+                    }) {
                         return false;
                     }
                 }
@@ -458,7 +461,7 @@ pub fn tree_sitter_language_for_extension(ext: &str) -> Option<tree_sitter::Lang
     })
 }
 
-pub fn is_excluded_dir_name(name: &str) -> bool {
+fn is_builtin_excluded_dir_name(name: &str) -> bool {
     matches!(
         name,
         ".venv"
@@ -493,6 +496,69 @@ pub fn is_excluded_dir_name(name: &str) -> bool {
             | ".parcel-cache"
             | "storybook-static"
     )
+}
+
+fn normalize_excluded_dir_name(raw: &str) -> Option<String> {
+    let trimmed = raw.trim().trim_end_matches(['/', '\\']);
+    if trimmed.is_empty() || trimmed.contains('/') || trimmed.contains('\\') {
+        return None;
+    }
+    Some(trimmed.to_ascii_lowercase())
+}
+
+pub fn extra_excluded_dir_names() -> HashSet<String> {
+    let mut names = HashSet::new();
+    if let Ok(value) = std::env::var(EXCLUDE_DIRS_ENV_VAR) {
+        for raw in value.split(',') {
+            if let Some(name) = normalize_excluded_dir_name(raw) {
+                names.insert(name);
+            }
+        }
+    }
+    names
+}
+
+pub fn extra_excluded_dir_patterns() -> Vec<String> {
+    let mut patterns = Vec::new();
+    for name in extra_excluded_dir_names() {
+        patterns.push(name.clone());
+        patterns.push(format!("{name}/**"));
+        patterns.push(format!("**/{name}"));
+        patterns.push(format!("**/{name}/**"));
+    }
+    patterns
+}
+
+pub fn default_exclude_patterns() -> Vec<String> {
+    let mut patterns = vec![
+        "target/**".to_string(),
+        ".git/**".to_string(),
+        "__pycache__/**".to_string(),
+        "node_modules/**".to_string(),
+        ".venv/**".to_string(),
+        "venv/**".to_string(),
+        "*.pyc".to_string(),
+    ];
+    patterns.extend(extra_excluded_dir_patterns());
+    patterns
+}
+
+pub fn is_excluded_dir_name_with_custom(name: &str, extra_excluded_dirs: &HashSet<String>) -> bool {
+    is_builtin_excluded_dir_name(name) || extra_excluded_dirs.contains(&name.to_ascii_lowercase())
+}
+
+pub fn is_excluded_dir_name(name: &str) -> bool {
+    let extra_excluded_dirs = extra_excluded_dir_names();
+    is_excluded_dir_name_with_custom(name, &extra_excluded_dirs)
+}
+
+#[cfg(test)]
+pub fn test_env_var_lock() -> &'static tokio::sync::Mutex<()> {
+    use std::sync::OnceLock;
+    use tokio::sync::Mutex;
+
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
 }
 
 #[cfg(test)]
@@ -545,6 +611,7 @@ mod tests {
 
     #[test]
     fn test_is_excluded_dir_name_known() {
+        let extra = HashSet::new();
         for name in &[
             "target",
             "node_modules",
@@ -565,15 +632,95 @@ mod tests {
             ".parcel-cache",
             "storybook-static",
         ] {
-            assert!(is_excluded_dir_name(name), "{name} should be excluded");
+            assert!(
+                is_excluded_dir_name_with_custom(name, &extra),
+                "{name} should be excluded"
+            );
         }
     }
 
     #[test]
     fn test_is_excluded_dir_name_unknown() {
+        let extra = HashSet::new();
         for name in &["src", "lib", "tests", "docs", "my_module"] {
-            assert!(!is_excluded_dir_name(name), "{name} should not be excluded");
+            assert!(
+                !is_excluded_dir_name_with_custom(name, &extra),
+                "{name} should not be excluded"
+            );
         }
+    }
+
+    #[test]
+    fn test_extra_excluded_dir_names_from_env() {
+        let _guard = test_env_var_lock().blocking_lock();
+        std::env::set_var(
+            EXCLUDE_DIRS_ENV_VAR,
+            " vendor , tmp/ ,nested/path,,cache\\inner",
+        );
+
+        let names = extra_excluded_dir_names();
+
+        assert!(names.contains("vendor"));
+        assert!(names.contains("tmp"));
+        assert_eq!(names.len(), 2);
+
+        std::env::remove_var(EXCLUDE_DIRS_ENV_VAR);
+    }
+
+    #[test]
+    fn test_is_excluded_dir_name_with_env_override() {
+        let _guard = test_env_var_lock().blocking_lock();
+        std::env::set_var(EXCLUDE_DIRS_ENV_VAR, "vendor");
+
+        assert!(is_excluded_dir_name("vendor"));
+        assert!(is_excluded_dir_name("Vendor"));
+        assert!(!is_excluded_dir_name("src"));
+
+        std::env::remove_var(EXCLUDE_DIRS_ENV_VAR);
+    }
+
+    #[test]
+    fn test_index_project_respects_env_excluded_dir_names() {
+        let _guard = test_env_var_lock().blocking_lock();
+        std::env::set_var(EXCLUDE_DIRS_ENV_VAR, "vendor");
+
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("lib.rs"), b"pub fn root() {}\n").unwrap();
+        std::fs::create_dir_all(dir.path().join("vendor")).unwrap();
+        std::fs::write(
+            dir.path().join("vendor/ignored.rs"),
+            b"pub fn ignored() {}\n",
+        )
+        .unwrap();
+
+        let (index, file_count) = create_indexer().index_project(dir.path(), &[]).unwrap();
+
+        assert_eq!(file_count, 1);
+        assert_eq!(index.symbol_count(), 1);
+
+        std::env::remove_var(EXCLUDE_DIRS_ENV_VAR);
+    }
+
+    #[test]
+    fn test_index_project_respects_env_excluded_dir_names_case_insensitively() {
+        let _guard = test_env_var_lock().blocking_lock();
+        std::env::set_var(EXCLUDE_DIRS_ENV_VAR, "vendor");
+
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("lib.rs"), b"pub fn root() {}\n").unwrap();
+        std::fs::create_dir_all(dir.path().join("Vendor")).unwrap();
+        std::fs::write(
+            dir.path().join("Vendor/ignored.rs"),
+            b"pub fn ignored() {}\n",
+        )
+        .unwrap();
+
+        let (index, file_count) = create_indexer().index_project(dir.path(), &[]).unwrap();
+
+        assert_eq!(file_count, 1);
+        assert_eq!(index.symbol_count(), 1);
+
+        std::env::remove_var(EXCLUDE_DIRS_ENV_VAR);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use pitlane_mcp::tools::watch_project::WatcherRegistry;
 pub struct EnsureProjectReadyRequest {
     /// Absolute or relative path to the project root
     pub path: String,
-    /// Glob patterns to exclude (default: target/, .git/, __pycache__/)
+    /// Glob patterns to exclude. Built-in defaults apply, and PITLANE_EXCLUDE_DIRS adds process-wide directory-name excludes.
     pub exclude: Option<Vec<String>>,
     /// Re-index even if an up-to-date index exists
     pub force: Option<bool>,
@@ -33,7 +33,7 @@ pub struct EnsureProjectReadyRequest {
 pub struct IndexProjectRequest {
     /// Absolute or relative path to the project root
     pub path: String,
-    /// Glob patterns to exclude (default: target/, .git/, __pycache__/)
+    /// Glob patterns to exclude. Built-in defaults apply, and PITLANE_EXCLUDE_DIRS adds process-wide directory-name excludes.
     pub exclude: Option<Vec<String>>,
     /// Re-index even if an up-to-date index exists
     pub force: Option<bool>,

--- a/src/tools/get_project_outline.rs
+++ b/src/tools/get_project_outline.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use serde_json::{json, Value};
 
 use crate::index::format::load_project_meta;
-use crate::indexer::is_excluded_dir_name;
+use crate::indexer::{extra_excluded_dir_names, is_excluded_dir_name_with_custom};
 use crate::path_policy::resolve_project_path;
 use crate::tools::index_project::load_project_index;
 use crate::tools::steering::{attach_steering, build_steering, take_fallback_candidates};
@@ -38,6 +38,7 @@ pub async fn get_project_outline(params: GetProjectOutlineParams) -> anyhow::Res
     let depth = params.depth.unwrap_or(2) as usize;
     let max_dirs = params.max_dirs.unwrap_or(50).min(HARD_MAX_DIRS);
     let summary = params.summary.unwrap_or(false);
+    let extra_excluded_dirs = extra_excluded_dir_names();
 
     // Normalise the optional path filter to a forward-slash prefix for matching.
     let path_filter: Option<String> = params.path.as_ref().map(|p| {
@@ -64,10 +65,11 @@ pub async fn get_project_outline(params: GetProjectOutlineParams) -> anyhow::Res
                 }
             }
 
-            if rel
-                .components()
-                .any(|c| c.as_os_str().to_str().is_some_and(is_excluded_dir_name))
-            {
+            if rel.components().any(|c| {
+                c.as_os_str().to_str().is_some_and(|name| {
+                    is_excluded_dir_name_with_custom(name, &extra_excluded_dirs)
+                })
+            }) {
                 continue;
             }
 
@@ -158,10 +160,11 @@ pub async fn get_project_outline(params: GetProjectOutlineParams) -> anyhow::Res
             }
         }
 
-        if rel
-            .components()
-            .any(|c| c.as_os_str().to_str().is_some_and(is_excluded_dir_name))
-        {
+        if rel.components().any(|c| {
+            c.as_os_str()
+                .to_str()
+                .is_some_and(|name| is_excluded_dir_name_with_custom(name, &extra_excluded_dirs))
+        }) {
             continue;
         }
 

--- a/src/tools/index_project.rs
+++ b/src/tools/index_project.rs
@@ -22,8 +22,9 @@ use crate::index::format::{
 };
 use crate::index::SymbolIndex;
 use crate::indexer::{
-    is_declaration_file, is_excluded_dir_name, is_supported_extension, load_gitignore_patterns,
-    registry, warn_walkdir_error, Indexer,
+    default_exclude_patterns, extra_excluded_dir_names, is_declaration_file,
+    is_excluded_dir_name_with_custom, is_supported_extension, load_gitignore_patterns, registry,
+    warn_walkdir_error, Indexer,
 };
 use crate::path_policy::resolve_project_path;
 
@@ -55,7 +56,7 @@ pub async fn index_project(mut params: IndexProjectParams) -> anyhow::Result<Val
     let force = params.force.unwrap_or(false);
     let mut exclude = params.exclude.take().unwrap_or_default();
     if exclude.is_empty() {
-        exclude = default_excludes();
+        exclude = default_exclude_patterns();
     }
 
     // Extend with patterns from the project's .gitignore (if present).
@@ -459,18 +460,6 @@ async fn do_index_project(
     Ok(response)
 }
 
-fn default_excludes() -> Vec<String> {
-    vec![
-        "target/**".to_string(),
-        ".git/**".to_string(),
-        "__pycache__/**".to_string(),
-        "node_modules/**".to_string(),
-        ".venv/**".to_string(),
-        "venv/**".to_string(),
-        "*.pyc".to_string(),
-    ]
-}
-
 fn build_exclude_set(patterns: &[String]) -> anyhow::Result<GlobSet> {
     let mut builder = GlobSetBuilder::new();
     for pattern in patterns {
@@ -484,6 +473,7 @@ fn current_file_mtimes(
     exclude_patterns: &[String],
 ) -> anyhow::Result<HashMap<String, u64>> {
     let exclude_set = build_exclude_set(exclude_patterns)?;
+    let extra_excluded_dirs = extra_excluded_dir_names();
     let mut file_mtimes = HashMap::new();
 
     for entry in WalkDir::new(project_path)
@@ -508,10 +498,11 @@ fn current_file_mtimes(
                 if exclude_set.is_match(format!("{}/", rel_str).as_str()) {
                     return false;
                 }
-                if rel
-                    .components()
-                    .any(|c| c.as_os_str().to_str().is_some_and(is_excluded_dir_name))
-                {
+                if rel.components().any(|c| {
+                    c.as_os_str().to_str().is_some_and(|name| {
+                        is_excluded_dir_name_with_custom(name, &extra_excluded_dirs)
+                    })
+                }) {
                     return false;
                 }
             }

--- a/src/tools/index_project.rs
+++ b/src/tools/index_project.rs
@@ -487,6 +487,7 @@ pub(crate) fn current_source_snapshot(
     exclude_patterns: &[String],
 ) -> anyhow::Result<SourceSnapshot> {
     let exclude_set = build_exclude_set(exclude_patterns)?;
+    let extra_excluded_dirs = extra_excluded_dir_names();
     let mut snapshot = SourceSnapshot::default();
 
     for entry in WalkDir::new(project_path)

--- a/src/tools/search_content.rs
+++ b/src/tools/search_content.rs
@@ -7,7 +7,10 @@ use serde_json::{json, Value};
 use walkdir::{DirEntry, WalkDir};
 
 use crate::error::ToolError;
-use crate::indexer::{is_declaration_file, is_supported_extension, load_gitignore_patterns};
+use crate::indexer::{
+    default_exclude_patterns, extra_excluded_dir_names, is_declaration_file,
+    is_excluded_dir_name_with_custom, is_supported_extension, load_gitignore_patterns,
+};
 use crate::path_policy::resolve_project_path;
 use crate::tools::index_project::load_project_index;
 use crate::tools::steering::{attach_steering, build_steering, take_fallback_candidates};
@@ -64,6 +67,7 @@ pub async fn search_content(params: SearchContentParams) -> anyhow::Result<Value
         .map(parse_language_filter)
         .transpose()?;
     let exclude_set = build_exclude_set(&canonical)?;
+    let extra_excluded_dirs = extra_excluded_dir_names();
 
     let matcher = if regex {
         ContentMatcher::Regex(
@@ -86,6 +90,7 @@ pub async fn search_content(params: SearchContentParams) -> anyhow::Result<Value
     let mut files = collect_searchable_files(
         &canonical,
         &exclude_set,
+        &extra_excluded_dirs,
         file_glob.as_ref(),
         language_filter,
     )?;
@@ -253,21 +258,9 @@ fn parse_language_filter(language: &str) -> anyhow::Result<&'static [&'static st
     }
 }
 
-fn default_excludes() -> Vec<String> {
-    vec![
-        "target/**".to_string(),
-        ".git/**".to_string(),
-        "__pycache__/**".to_string(),
-        "node_modules/**".to_string(),
-        ".venv/**".to_string(),
-        "venv/**".to_string(),
-        "*.pyc".to_string(),
-    ]
-}
-
 fn build_exclude_set(root: &Path) -> anyhow::Result<GlobSet> {
     let mut builder = GlobSetBuilder::new();
-    for pattern in default_excludes()
+    for pattern in default_exclude_patterns()
         .into_iter()
         .chain(load_gitignore_patterns(root))
     {
@@ -279,6 +272,7 @@ fn build_exclude_set(root: &Path) -> anyhow::Result<GlobSet> {
 fn collect_searchable_files(
     root: &Path,
     exclude_set: &GlobSet,
+    extra_excluded_dirs: &std::collections::HashSet<String>,
     file_glob: Option<&globset::GlobMatcher>,
     language_filter: Option<&[&str]>,
 ) -> anyhow::Result<Vec<PathBuf>> {
@@ -286,7 +280,7 @@ fn collect_searchable_files(
     for entry in WalkDir::new(root)
         .follow_links(false)
         .into_iter()
-        .filter_entry(|entry| should_descend(root, exclude_set, entry))
+        .filter_entry(|entry| should_descend(root, exclude_set, extra_excluded_dirs, entry))
     {
         let entry = entry?;
         let path = entry.path();
@@ -307,6 +301,14 @@ fn collect_searchable_files(
         }
         let rel = path.strip_prefix(root).unwrap_or(path);
         let rel_str = rel.to_string_lossy();
+        if rel.components().any(|component| {
+            component
+                .as_os_str()
+                .to_str()
+                .is_some_and(|name| is_excluded_dir_name_with_custom(name, extra_excluded_dirs))
+        }) {
+            continue;
+        }
         if exclude_set.is_match(rel_str.as_ref()) || exclude_set.is_match(path) {
             continue;
         }
@@ -321,7 +323,12 @@ fn collect_searchable_files(
     Ok(files)
 }
 
-fn should_descend(root: &Path, exclude_set: &GlobSet, entry: &DirEntry) -> bool {
+fn should_descend(
+    root: &Path,
+    exclude_set: &GlobSet,
+    extra_excluded_dirs: &std::collections::HashSet<String>,
+    entry: &DirEntry,
+) -> bool {
     let path = entry.path();
     let rel = match path.strip_prefix(root) {
         Ok(rel) => rel,
@@ -332,6 +339,14 @@ fn should_descend(root: &Path, exclude_set: &GlobSet, entry: &DirEntry) -> bool 
     }
     let rel_str = rel.to_string_lossy();
     if exclude_set.is_match(rel_str.as_ref()) {
+        return false;
+    }
+    if rel.components().any(|component| {
+        component
+            .as_os_str()
+            .to_str()
+            .is_some_and(|name| is_excluded_dir_name_with_custom(name, extra_excluded_dirs))
+    }) {
         return false;
     }
     if entry.file_type().is_dir() && exclude_set.is_match(format!("{rel_str}/").as_str()) {
@@ -351,7 +366,7 @@ fn rel_string(root: &Path, path: &Path) -> String {
 mod tests {
     use super::*;
     use crate::index::format::{index_dir, save_index};
-    use crate::indexer::{registry, Indexer};
+    use crate::indexer::{registry, test_env_var_lock, Indexer, EXCLUDE_DIRS_ENV_VAR};
     use tempfile::TempDir;
 
     fn setup_indexed_project(dir: &TempDir) -> String {
@@ -429,5 +444,36 @@ mod tests {
             result["guidance"]["next_step"],
             json!("Use the matched file paths to pivot back to get_file_outline, search_symbols, or get_symbol instead of repeating nearby text searches.")
         );
+    }
+
+    #[tokio::test]
+    async fn test_search_content_respects_env_excluded_dir_names() {
+        let _guard = test_env_var_lock().lock().await;
+        std::env::set_var(EXCLUDE_DIRS_ENV_VAR, "vendor");
+
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("lib.rs"), "fn keep_me() {}\n").unwrap();
+        std::fs::create_dir_all(dir.path().join("vendor")).unwrap();
+        std::fs::write(dir.path().join("vendor/ignored.rs"), "fn find_me() {}\n").unwrap();
+        let project = setup_indexed_project(&dir);
+
+        let result = search_content(SearchContentParams {
+            project,
+            query: "find_me".to_string(),
+            regex: None,
+            case_sensitive: None,
+            language: Some("rust".to_string()),
+            file: None,
+            limit: None,
+            offset: None,
+            before_context: None,
+            after_context: None,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(result["count"], json!(0));
+
+        std::env::remove_var(EXCLUDE_DIRS_ENV_VAR);
     }
 }

--- a/src/tools/search_files.rs
+++ b/src/tools/search_files.rs
@@ -9,7 +9,10 @@ use walkdir::{DirEntry, WalkDir};
 use crate::error::ToolError;
 use crate::index::format::load_project_meta;
 use crate::index::repo_profile::{archetype_label, role_boost_for_path, role_by_path, role_label};
-use crate::indexer::load_gitignore_patterns;
+use crate::indexer::{
+    default_exclude_patterns, extra_excluded_dir_names, is_excluded_dir_name_with_custom,
+    load_gitignore_patterns,
+};
 use crate::path_policy::resolve_project_path;
 use crate::session;
 use crate::tools::index_project::load_project_index;
@@ -60,13 +63,16 @@ pub async fn search_files(params: SearchFilesParams) -> anyhow::Result<Value> {
                 .map(|g| g.compile_matcher())
         })
         .transpose()?;
-    let exclude_set = build_exclude_set(&canonical)?;
+    let exclusions = ExclusionContext {
+        exclude_set: build_exclude_set(&canonical)?,
+        extra_excluded_dirs: extra_excluded_dir_names(),
+    };
 
     let matcher = FileMatcher::new(mode, &params.query)?;
 
     let mut matches: Vec<FileMatch> = collect_files(
         &canonical,
-        &exclude_set,
+        &exclusions,
         scope_glob.as_ref(),
         language_filter,
         &matcher,
@@ -166,6 +172,11 @@ struct FileMatch {
     path_role: Option<String>,
 }
 
+struct ExclusionContext {
+    exclude_set: GlobSet,
+    extra_excluded_dirs: std::collections::HashSet<String>,
+}
+
 enum FileMatcher {
     Exact { query: String },
     Substring { query: String },
@@ -257,7 +268,7 @@ fn compare_matches(a: &FileMatch, b: &FileMatch) -> Ordering {
 
 fn collect_files(
     root: &Path,
-    exclude_set: &GlobSet,
+    exclusions: &ExclusionContext,
     scope_glob: Option<&globset::GlobMatcher>,
     language_filter: Option<&[&str]>,
     matcher: &FileMatcher,
@@ -268,7 +279,7 @@ fn collect_files(
     for entry in WalkDir::new(root)
         .follow_links(false)
         .into_iter()
-        .filter_entry(|entry| should_descend(root, exclude_set, entry))
+        .filter_entry(|entry| should_descend(root, exclusions, entry))
     {
         let entry = entry?;
         let path = entry.path();
@@ -277,7 +288,16 @@ fn collect_files(
         }
         let rel = path.strip_prefix(root).unwrap_or(path);
         let rel_str = rel.to_string_lossy().replace('\\', "/");
-        if exclude_set.is_match(rel_str.as_str()) || exclude_set.is_match(path) {
+        if rel.components().any(|component| {
+            component.as_os_str().to_str().is_some_and(|name| {
+                is_excluded_dir_name_with_custom(name, &exclusions.extra_excluded_dirs)
+            })
+        }) {
+            continue;
+        }
+        if exclusions.exclude_set.is_match(rel_str.as_str())
+            || exclusions.exclude_set.is_match(path)
+        {
             continue;
         }
         if let Some(scope) = scope_glob {
@@ -369,21 +389,9 @@ fn trigrams(s: &str) -> std::collections::HashSet<[char; 3]> {
     chars.windows(3).map(|w| [w[0], w[1], w[2]]).collect()
 }
 
-fn default_excludes() -> Vec<String> {
-    vec![
-        "target/**".to_string(),
-        ".git/**".to_string(),
-        "__pycache__/**".to_string(),
-        "node_modules/**".to_string(),
-        ".venv/**".to_string(),
-        "venv/**".to_string(),
-        "*.pyc".to_string(),
-    ]
-}
-
 fn build_exclude_set(root: &Path) -> anyhow::Result<GlobSet> {
     let mut builder = GlobSetBuilder::new();
-    for pattern in default_excludes()
+    for pattern in default_exclude_patterns()
         .into_iter()
         .chain(load_gitignore_patterns(root))
     {
@@ -392,7 +400,7 @@ fn build_exclude_set(root: &Path) -> anyhow::Result<GlobSet> {
     Ok(builder.build()?)
 }
 
-fn should_descend(root: &Path, exclude_set: &GlobSet, entry: &DirEntry) -> bool {
+fn should_descend(root: &Path, exclusions: &ExclusionContext, entry: &DirEntry) -> bool {
     let path = entry.path();
     let rel = match path.strip_prefix(root) {
         Ok(rel) => rel,
@@ -402,10 +410,21 @@ fn should_descend(root: &Path, exclude_set: &GlobSet, entry: &DirEntry) -> bool 
         return true;
     }
     let rel_str = rel.to_string_lossy();
-    if exclude_set.is_match(rel_str.as_ref()) {
+    if exclusions.exclude_set.is_match(rel_str.as_ref()) {
         return false;
     }
-    if entry.file_type().is_dir() && exclude_set.is_match(format!("{rel_str}/").as_str()) {
+    if rel.components().any(|component| {
+        component.as_os_str().to_str().is_some_and(|name| {
+            is_excluded_dir_name_with_custom(name, &exclusions.extra_excluded_dirs)
+        })
+    }) {
+        return false;
+    }
+    if entry.file_type().is_dir()
+        && exclusions
+            .exclude_set
+            .is_match(format!("{rel_str}/").as_str())
+    {
         return false;
     }
     true
@@ -415,7 +434,7 @@ fn should_descend(root: &Path, exclude_set: &GlobSet, entry: &DirEntry) -> bool 
 mod tests {
     use super::*;
     use crate::index::format::{build_index_meta, index_dir, save_index, save_meta};
-    use crate::indexer::{registry, Indexer};
+    use crate::indexer::{registry, test_env_var_lock, Indexer, EXCLUDE_DIRS_ENV_VAR};
     use tempfile::TempDir;
 
     fn setup_indexed_project(dir: &TempDir) -> String {
@@ -512,5 +531,37 @@ mod tests {
             result["guidance"]["next_step"],
             json!("Use the returned file paths with get_file_outline, search_content, or get_symbol instead of switching to shell globbing.")
         );
+    }
+
+    #[tokio::test]
+    async fn test_search_files_respects_env_excluded_dir_names() {
+        let _guard = test_env_var_lock().lock().await;
+        std::env::set_var(EXCLUDE_DIRS_ENV_VAR, "vendor");
+
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("root.rs"), "fn root() {}\n").unwrap();
+        std::fs::create_dir_all(dir.path().join("vendor")).unwrap();
+        std::fs::write(
+            dir.path().join("vendor/SecretFeatureTest.java"),
+            "class SecretFeatureTest {}\n",
+        )
+        .unwrap();
+        let project = setup_indexed_project(&dir);
+
+        let result = search_files(SearchFilesParams {
+            project,
+            query: "SecretFeature".to_string(),
+            mode: None,
+            language: None,
+            file: None,
+            limit: None,
+            offset: None,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(result["count"], json!(0));
+
+        std::env::remove_var(EXCLUDE_DIRS_ENV_VAR);
     }
 }


### PR DESCRIPTION
## Summary
- add PITLANE_EXCLUDE_DIRS as a process-level directory-name exclusion override
- apply the override consistently across indexing, ensure_project_ready, search_content, search_files, and get_project_outline
- normalize custom exclude names case-insensitively so mixed-case directories behave correctly on Windows
- add focused regression tests and keep the test env-var lock clippy-clean with tokio::sync::Mutex

## Validation
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --lib

## Notes
- PITLANE_EXCLUDE_DIRS is intentionally limited to comma-separated directory basenames at any depth
- path-like entries such as foo/bar are ignored to avoid turning this into a second path/glob configuration surface