### PR TITLE
[codex] reject symlinked source files

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -6,6 +6,7 @@ use tree_sitter::{Node, Parser};
 
 use crate::index::SymbolIndex;
 use crate::indexer::language::{Language, Symbol, SymbolKind};
+use crate::path_policy::regular_file_metadata;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct DirectReference {
@@ -66,6 +67,10 @@ pub fn extract_identifiers(source: &str) -> HashSet<&str> {
 }
 
 pub fn read_symbol_source(sym: &Symbol, include_context: bool) -> anyhow::Result<String> {
+    if regular_file_metadata(sym.file.as_ref())?.is_none() {
+        anyhow::bail!("Refusing to read non-regular file {:?}", sym.file);
+    }
+
     let mut file = std::fs::File::open(&*sym.file)
         .map_err(|e| anyhow::anyhow!("Cannot open file {:?}: {}", sym.file, e))?;
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -6,7 +6,7 @@ use tree_sitter::{Node, Parser};
 
 use crate::index::SymbolIndex;
 use crate::indexer::language::{Language, Symbol, SymbolKind};
-use crate::path_policy::regular_file_metadata;
+use crate::path_policy::open_regular_file;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct DirectReference {
@@ -67,11 +67,7 @@ pub fn extract_identifiers(source: &str) -> HashSet<&str> {
 }
 
 pub fn read_symbol_source(sym: &Symbol, include_context: bool) -> anyhow::Result<String> {
-    if regular_file_metadata(sym.file.as_ref())?.is_none() {
-        anyhow::bail!("Refusing to read non-regular file {:?}", sym.file);
-    }
-
-    let mut file = std::fs::File::open(&*sym.file)
+    let mut file = open_regular_file(sym.file.as_ref())
         .map_err(|e| anyhow::anyhow!("Cannot open file {:?}: {}", sym.file, e))?;
 
     if include_context {

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -30,6 +30,7 @@ use tracing::{debug, warn};
 use walkdir::WalkDir;
 
 use crate::index::SymbolIndex;
+use crate::path_policy::regular_file_metadata;
 use language::LanguageParser;
 
 /// Files larger than this are skipped to avoid memory exhaustion and parser hangs.
@@ -130,7 +131,7 @@ impl Indexer {
             })
             .filter(|e| {
                 let path = e.path();
-                if !path.is_file() {
+                if !e.file_type().is_file() {
                     return false;
                 }
                 let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
@@ -145,7 +146,10 @@ impl Indexer {
                 if exclude_set.is_match(rel_str.as_ref()) || exclude_set.is_match(path) {
                     return false;
                 }
-                if e.metadata().map(|m| m.len()).unwrap_or(0) > MAX_FILE_BYTES {
+                let Some(metadata) = regular_file_metadata(path).ok().flatten() else {
+                    return false;
+                };
+                if metadata.len() > MAX_FILE_BYTES {
                     warn!(file = %rel_str, limit = MAX_FILE_BYTES, "skipping oversized file");
                     return false;
                 }
@@ -270,8 +274,11 @@ impl Indexer {
             None => return Ok(vec![]),
         };
 
-        // Guard against oversized files (e.g. minified bundles, generated data dicts)
-        let file_size = path.metadata().map(|m| m.len()).unwrap_or(0);
+        // Guard against symlinks and oversized files (e.g. minified bundles).
+        let Some(metadata) = regular_file_metadata(path)? else {
+            return Ok(vec![]);
+        };
+        let file_size = metadata.len();
         if file_size > MAX_FILE_BYTES {
             warn!(file = %path.display(), limit = MAX_FILE_BYTES, "skipping oversized file");
             return Ok(vec![]);
@@ -1124,6 +1131,26 @@ mod tests {
 
         // Previous symbols removed, oversized file produces no new symbols
         assert_eq!(index.symbol_count(), 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_index_project_skips_file_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let project = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let outside_file = outside.path().join("secret.rs");
+        std::fs::write(&outside_file, b"fn outside_secret() {}\n").unwrap();
+        std::fs::write(project.path().join("lib.rs"), b"fn inside() {}\n").unwrap();
+        symlink(&outside_file, project.path().join("linked_secret.rs")).unwrap();
+
+        let (index, file_count) = create_indexer().index_project(project.path(), &[]).unwrap();
+
+        assert_eq!(file_count, 1);
+        let names: Vec<_> = index.symbols.values().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"inside"));
+        assert!(!names.contains(&"outside_secret"));
     }
 
     // ── load_gitignore_patterns ──────────────────────────────────────────────

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -30,7 +30,7 @@ use tracing::{debug, warn};
 use walkdir::WalkDir;
 
 use crate::index::SymbolIndex;
-use crate::path_policy::regular_file_metadata;
+use crate::path_policy::{read_regular_file, regular_file_metadata};
 use language::LanguageParser;
 
 /// Files larger than this are skipped to avoid memory exhaustion and parser hangs.
@@ -285,7 +285,7 @@ impl Indexer {
         }
 
         debug!(file = %path.display(), bytes = file_size, "parsing file");
-        let source = std::fs::read(path)?;
+        let source = read_regular_file(path)?;
         let lang_parser = &self.parsers[parser_idx];
 
         let mut ts_parser = tree_sitter::Parser::new();
@@ -1151,6 +1151,27 @@ mod tests {
         let names: Vec<_> = index.symbols.values().map(|s| s.name.as_str()).collect();
         assert!(names.contains(&"inside"));
         assert!(!names.contains(&"outside_secret"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_index_project_skips_in_project_file_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let project = TempDir::new().unwrap();
+        std::fs::write(project.path().join("real.rs"), b"fn real() {}\n").unwrap();
+        symlink("real.rs", project.path().join("linked_real.rs")).unwrap();
+
+        let (index, file_count) = create_indexer().index_project(project.path(), &[]).unwrap();
+
+        assert_eq!(file_count, 1);
+        let files: Vec<_> = index
+            .symbols
+            .values()
+            .map(|s| s.file.file_name().unwrap().to_string_lossy().to_string())
+            .collect();
+        assert!(files.contains(&"real.rs".to_string()));
+        assert!(!files.contains(&"linked_real.rs".to_string()));
     }
 
     // ── load_gitignore_patterns ──────────────────────────────────────────────

--- a/src/path_policy.rs
+++ b/src/path_policy.rs
@@ -32,10 +32,7 @@ pub fn regular_file_metadata(path: &Path) -> anyhow::Result<Option<std::fs::Meta
 }
 
 pub fn is_regular_file(path: &Path) -> bool {
-    regular_file_metadata(path)
-        .ok()
-        .flatten()
-        .is_some()
+    matches!(regular_file_metadata(path), Ok(Some(_)))
 }
 
 fn configured_allowed_roots() -> anyhow::Result<Option<Vec<PathBuf>>> {

--- a/src/path_policy.rs
+++ b/src/path_policy.rs
@@ -8,6 +8,36 @@ use anyhow::Context;
 
 use crate::error::ToolError;
 
+/// Return metadata only for ordinary files, without following symlinks.
+///
+/// WalkDir is configured with `follow_links(false)`, but `Path::is_file()` and
+/// `std::fs::metadata()` still follow file symlinks. Use this helper at read
+/// boundaries so a symlink inside an allowed project cannot expose a file
+/// outside that project.
+pub fn regular_file_metadata(path: &Path) -> anyhow::Result<Option<std::fs::Metadata>> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("Cannot inspect file: {}", path.display()));
+        }
+    };
+
+    if metadata.file_type().is_file() {
+        Ok(Some(metadata))
+    } else {
+        Ok(None)
+    }
+}
+
+pub fn is_regular_file(path: &Path) -> bool {
+    regular_file_metadata(path)
+        .ok()
+        .flatten()
+        .is_some()
+}
+
 fn configured_allowed_roots() -> anyhow::Result<Option<Vec<PathBuf>>> {
     #[cfg(test)]
     let raw = test_allowed_roots_override().with(|slot| slot.borrow().clone());
@@ -176,5 +206,21 @@ mod tests {
             resolve_project_file(&dir.path().canonicalize().unwrap(), "../secret.rs").unwrap_err();
         let err = err.downcast::<ToolError>().unwrap();
         assert!(matches!(err, ToolError::AccessDenied { .. }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn regular_file_metadata_rejects_file_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("target.rs");
+        let link = dir.path().join("link.rs");
+        std::fs::write(&target, "fn target() {}\n").unwrap();
+        symlink(&target, &link).unwrap();
+
+        assert!(regular_file_metadata(&target).unwrap().is_some());
+        assert!(regular_file_metadata(&link).unwrap().is_none());
+        assert!(!is_regular_file(&link));
     }
 }

--- a/src/path_policy.rs
+++ b/src/path_policy.rs
@@ -19,8 +19,7 @@ pub fn regular_file_metadata(path: &Path) -> anyhow::Result<Option<std::fs::Meta
         Ok(metadata) => metadata,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(err) => {
-            return Err(err)
-                .with_context(|| format!("Cannot inspect file: {}", path.display()));
+            return Err(err).with_context(|| format!("Cannot inspect file: {}", path.display()));
         }
     };
 

--- a/src/path_policy.rs
+++ b/src/path_policy.rs
@@ -34,6 +34,17 @@ pub fn is_regular_file(path: &Path) -> bool {
     matches!(regular_file_metadata(path), Ok(Some(_)))
 }
 
+/// Return a canonical path for an ordinary file, without allowing the final
+/// path component to be a symlink.
+pub fn canonical_regular_file(path: &Path) -> anyhow::Result<Option<PathBuf>> {
+    if regular_file_metadata(path)?.is_none() {
+        return Ok(None);
+    }
+    Ok(Some(path.canonicalize().with_context(|| {
+        format!("Cannot canonicalize file: {}", path.display())
+    })?))
+}
+
 /// Open an ordinary source file without following a final symlink component.
 ///
 /// This closes the check-then-open race for source reads on supported platforms:

--- a/src/path_policy.rs
+++ b/src/path_policy.rs
@@ -34,6 +34,68 @@ pub fn is_regular_file(path: &Path) -> bool {
     matches!(regular_file_metadata(path), Ok(Some(_)))
 }
 
+/// Open an ordinary source file without following a final symlink component.
+///
+/// This closes the check-then-open race for source reads on supported platforms:
+/// the open itself refuses or preserves final-component symlinks, then the
+/// opened handle is checked before any bytes are read.
+pub fn open_regular_file(path: &Path) -> anyhow::Result<std::fs::File> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(path)
+            .with_context(|| format!("Cannot open regular file: {}", path.display()))?;
+        if !file.metadata()?.file_type().is_file() {
+            anyhow::bail!("Refusing to read non-regular file: {}", path.display());
+        }
+        Ok(file)
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+
+        const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+            .open(path)
+            .with_context(|| format!("Cannot open regular file: {}", path.display()))?;
+        let file_type = file.metadata()?.file_type();
+        if !file_type.is_file() || file_type.is_symlink() {
+            anyhow::bail!("Refusing to read non-regular file: {}", path.display());
+        }
+        Ok(file)
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        if regular_file_metadata(path)?.is_none() {
+            anyhow::bail!("Refusing to read non-regular file: {}", path.display());
+        }
+        let file = std::fs::File::open(path)
+            .with_context(|| format!("Cannot open regular file: {}", path.display()))?;
+        if !file.metadata()?.file_type().is_file() {
+            anyhow::bail!("Refusing to read non-regular file: {}", path.display());
+        }
+        Ok(file)
+    }
+}
+
+pub fn read_regular_file(path: &Path) -> anyhow::Result<Vec<u8>> {
+    use std::io::Read;
+
+    let mut file = open_regular_file(path)?;
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)?;
+    Ok(bytes)
+}
+
 fn configured_allowed_roots() -> anyhow::Result<Option<Vec<PathBuf>>> {
     #[cfg(test)]
     let raw = test_allowed_roots_override().with(|slot| slot.borrow().clone());
@@ -218,5 +280,20 @@ mod tests {
         assert!(regular_file_metadata(&target).unwrap().is_some());
         assert!(regular_file_metadata(&link).unwrap().is_none());
         assert!(!is_regular_file(&link));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_regular_file_rejects_in_project_file_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("target.rs");
+        let link = dir.path().join("link.rs");
+        std::fs::write(&target, "fn target() {}\n").unwrap();
+        symlink("target.rs", &link).unwrap();
+
+        assert!(read_regular_file(&target).is_ok());
+        assert!(read_regular_file(&link).is_err());
     }
 }

--- a/src/tools/find_usages.rs
+++ b/src/tools/find_usages.rs
@@ -10,7 +10,7 @@ use crate::indexer::svelte::{collect_script_blocks, ScriptBlockLanguage};
 use crate::indexer::{
     is_supported_extension, tree_sitter_language_for_extension, warn_walkdir_error,
 };
-use crate::path_policy::resolve_project_path;
+use crate::path_policy::{is_regular_file, regular_file_metadata, resolve_project_path};
 use crate::tools::index_project::load_project_index;
 
 pub struct FindUsagesParams {
@@ -124,7 +124,7 @@ pub async fn find_usages(params: FindUsagesParams) -> anyhow::Result<Value> {
 }
 
 fn should_search_path(path: &Path, project_path: &Path, scope_set: Option<&GlobSet>) -> bool {
-    if !path.is_file() {
+    if !is_regular_file(path) {
         return false;
     }
 
@@ -173,7 +173,10 @@ fn search_file_ast(path: &Path, name: &str) -> anyhow::Result<Vec<(usize, usize,
     let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
 
     // Skip oversized files (same guard as the indexer)
-    if path.metadata().map(|m| m.len()).unwrap_or(0) > 1024 * 1024 {
+    let Some(metadata) = regular_file_metadata(path)? else {
+        return Ok(vec![]);
+    };
+    if metadata.len() > 1024 * 1024 {
         return Ok(vec![]);
     }
 
@@ -520,6 +523,23 @@ mod tests {
         assert!(std::fs::metadata(&path).unwrap().len() > 1024 * 1024);
         let hits = search_file_ast(&path, "foo").unwrap();
         assert!(hits.is_empty(), "oversized file must be skipped");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_search_file_ast_skips_file_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let project_dir = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let outside_file = outside.path().join("secret.rs");
+        std::fs::write(&outside_file, "fn outside_secret() {}\n").unwrap();
+        let link = project_dir.path().join("linked_secret.rs");
+        symlink(&outside_file, &link).unwrap();
+
+        let hits = search_file_ast(&link, "outside_secret").unwrap();
+
+        assert!(hits.is_empty(), "symlinked files must not be read");
     }
 
     // ── JavaScript ──────────────────────────────────────────────────────────

--- a/src/tools/find_usages.rs
+++ b/src/tools/find_usages.rs
@@ -10,7 +10,9 @@ use crate::indexer::svelte::{collect_script_blocks, ScriptBlockLanguage};
 use crate::indexer::{
     is_supported_extension, tree_sitter_language_for_extension, warn_walkdir_error,
 };
-use crate::path_policy::{is_regular_file, regular_file_metadata, resolve_project_path};
+use crate::path_policy::{
+    is_regular_file, read_regular_file, regular_file_metadata, resolve_project_path,
+};
 use crate::tools::index_project::load_project_index;
 
 pub struct FindUsagesParams {
@@ -180,7 +182,7 @@ fn search_file_ast(path: &Path, name: &str) -> anyhow::Result<Vec<(usize, usize,
         return Ok(vec![]);
     }
 
-    let source = std::fs::read(path)?;
+    let source = read_regular_file(path)?;
     let source_str = std::str::from_utf8(&source).unwrap_or("");
 
     // Fast pre-filter: if the symbol name doesn't appear anywhere in the file

--- a/src/tools/index_project.rs
+++ b/src/tools/index_project.rs
@@ -26,7 +26,7 @@ use crate::indexer::{
     is_excluded_dir_name_with_custom, is_supported_extension, load_gitignore_patterns, registry,
     warn_walkdir_error, Indexer,
 };
-use crate::path_policy::resolve_project_path;
+use crate::path_policy::{is_regular_file, resolve_project_path};
 
 /// Default cap on the number of eligible source files per walk.
 /// Prevents accidental full-filesystem indexing (e.g. `index_project("/")`).
@@ -474,7 +474,11 @@ fn build_exclude_set(patterns: &[String]) -> anyhow::Result<GlobSet> {
 }
 
 fn modified_secs(path: &Path) -> anyhow::Result<u64> {
-    let meta = std::fs::metadata(path)?;
+    let meta = std::fs::symlink_metadata(path)?;
+    let file_type = meta.file_type();
+    if !(file_type.is_file() || file_type.is_dir()) {
+        anyhow::bail!("Refusing to stat non-regular source path: {}", path.display());
+    }
     let modified = meta.modified()?;
     Ok(modified
         .duration_since(std::time::UNIX_EPOCH)
@@ -539,7 +543,7 @@ pub(crate) fn current_source_snapshot(
             snapshot.dir_mtimes.insert(path.display().to_string(), secs);
             continue;
         }
-        if !path.is_file() {
+        if !entry.file_type().is_file() {
             continue;
         }
 
@@ -585,6 +589,9 @@ fn is_index_up_to_date(project_path: &Path, meta: &IndexMeta, exclude_patterns: 
 
     for (path_str, stored_mtime) in &meta.file_mtimes {
         let path = Path::new(path_str);
+        if !is_regular_file(path) {
+            return false;
+        }
         let secs = match modified_secs(path) {
             Ok(secs) => secs,
             Err(_) => return false,
@@ -652,7 +659,20 @@ pub fn load_project_index(project: &str) -> anyhow::Result<Arc<SymbolIndex>> {
         .into());
     }
 
-    let index = crate::index::format::load_index(&index_path)?;
+    let mut index = crate::index::format::load_index(&index_path)?;
+    let before = index.symbol_count();
+    index.symbols.retain(|_, sym| {
+        sym.file.as_ref().starts_with(&canonical) && is_regular_file(sym.file.as_ref())
+    });
+    if index.symbol_count() != before {
+        tracing::warn!(
+            before,
+            after = index.symbol_count(),
+            "dropped unsafe or stale symbols while loading index"
+        );
+        index.rebuild_secondary_indexes();
+        index.graph = crate::graph::NavigationGraph::default();
+    }
     Ok(crate::cache::insert(canonical, index))
 }
 
@@ -661,8 +681,10 @@ mod tests {
     use super::*;
     use crate::embed::EmbedConfig;
     use crate::index::format::{index_dir, save_index};
+    use crate::indexer::language::{make_symbol_id, Language, Symbol, SymbolKind};
     use crate::indexer::{registry, Indexer};
     use crate::path_policy::set_test_allowed_roots;
+    use std::sync::Arc;
     use tempfile::TempDir;
 
     #[cfg(unix)]
@@ -775,6 +797,48 @@ mod tests {
 
         assert!(mtimes.keys().any(|path| path.ends_with("lib.rs")));
         assert_eq!(mtimes.len(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_load_project_index_drops_symlink_backed_symbols() {
+        use std::os::unix::fs::symlink;
+
+        let project = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let outside_file = outside.path().join("secret.rs");
+        std::fs::write(&outside_file, b"fn outside_secret() {}\n").unwrap();
+        let link = project.path().join("linked_secret.rs");
+        symlink(&outside_file, &link).unwrap();
+
+        let canonical = project.path().canonicalize().unwrap();
+        let mut index = SymbolIndex::new();
+        let rel = Path::new("linked_secret.rs");
+        let id = make_symbol_id(rel, "outside_secret", &SymbolKind::Function);
+        index.insert(Symbol {
+            id: id.clone(),
+            name: "outside_secret".to_string(),
+            qualified: "outside_secret".to_string(),
+            kind: SymbolKind::Function,
+            language: Language::Rust,
+            file: Arc::new(link),
+            byte_start: 0,
+            byte_end: 22,
+            line_start: 1,
+            line_end: 1,
+            signature: Some("fn outside_secret()".to_string()),
+            doc: None,
+        });
+
+        let idx_dir = index_dir(&canonical).unwrap();
+        std::fs::create_dir_all(&idx_dir).unwrap();
+        save_index(&index, &idx_dir.join("index.bin")).unwrap();
+        crate::cache::invalidate(&canonical);
+
+        let loaded = load_project_index(project.path().to_string_lossy().as_ref()).unwrap();
+
+        assert!(!loaded.symbols.contains_key(&id));
+        assert_eq!(loaded.symbol_count(), 0);
     }
 
     #[test]

--- a/src/tools/index_project.rs
+++ b/src/tools/index_project.rs
@@ -477,7 +477,10 @@ fn modified_secs(path: &Path) -> anyhow::Result<u64> {
     let meta = std::fs::symlink_metadata(path)?;
     let file_type = meta.file_type();
     if !(file_type.is_file() || file_type.is_dir()) {
-        anyhow::bail!("Refusing to stat non-regular source path: {}", path.display());
+        anyhow::bail!(
+            "Refusing to stat non-regular source path: {}",
+            path.display()
+        );
     }
     let modified = meta.modified()?;
     Ok(modified

--- a/src/tools/index_project.rs
+++ b/src/tools/index_project.rs
@@ -26,7 +26,7 @@ use crate::indexer::{
     is_excluded_dir_name_with_custom, is_supported_extension, load_gitignore_patterns, registry,
     warn_walkdir_error, Indexer,
 };
-use crate::path_policy::{is_regular_file, resolve_project_path};
+use crate::path_policy::{canonical_regular_file, is_regular_file, resolve_project_path};
 
 /// Default cap on the number of eligible source files per walk.
 /// Prevents accidental full-filesystem indexing (e.g. `index_project("/")`).
@@ -665,7 +665,14 @@ pub fn load_project_index(project: &str) -> anyhow::Result<Arc<SymbolIndex>> {
     let mut index = crate::index::format::load_index(&index_path)?;
     let before = index.symbol_count();
     index.symbols.retain(|_, sym| {
-        sym.file.as_ref().starts_with(&canonical) && is_regular_file(sym.file.as_ref())
+        let Ok(Some(canonical_file)) = canonical_regular_file(sym.file.as_ref()) else {
+            return false;
+        };
+        if !canonical_file.starts_with(&canonical) {
+            return false;
+        }
+        sym.file = Arc::new(canonical_file);
+        true
     });
     if index.symbol_count() != before {
         tracing::warn!(
@@ -842,6 +849,38 @@ mod tests {
 
         assert!(!loaded.symbols.contains_key(&id));
         assert_eq!(loaded.symbol_count(), 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_load_project_index_keeps_symbols_under_symlinked_parent() {
+        use std::os::unix::fs::symlink;
+
+        let real_parent = TempDir::new().unwrap();
+        let real_project = real_parent.path().join("project");
+        std::fs::create_dir(&real_project).unwrap();
+        std::fs::write(real_project.join("lib.rs"), b"fn inside() {}\n").unwrap();
+
+        let alias_parent = TempDir::new().unwrap();
+        let alias_root = alias_parent.path().join("alias_parent");
+        symlink(real_parent.path(), &alias_root).unwrap();
+        let alias_project = alias_root.join("project");
+
+        let indexer = Indexer::new(registry::build_default_registry());
+        let (index, _) = indexer.index_project(&alias_project, &[]).unwrap();
+        let canonical = alias_project.canonicalize().unwrap();
+        let idx_dir = index_dir(&canonical).unwrap();
+        std::fs::create_dir_all(&idx_dir).unwrap();
+        save_index(&index, &idx_dir.join("index.bin")).unwrap();
+        crate::cache::invalidate(&canonical);
+
+        let loaded = load_project_index(alias_project.to_string_lossy().as_ref()).unwrap();
+
+        assert_eq!(loaded.symbol_count(), 1);
+        assert!(loaded
+            .symbols
+            .values()
+            .all(|sym| sym.file.starts_with(&canonical)));
     }
 
     #[test]

--- a/src/tools/search_content.rs
+++ b/src/tools/search_content.rs
@@ -11,7 +11,7 @@ use crate::indexer::{
     default_exclude_patterns, extra_excluded_dir_names, is_declaration_file,
     is_excluded_dir_name_with_custom, is_supported_extension, load_gitignore_patterns,
 };
-use crate::path_policy::resolve_project_path;
+use crate::path_policy::{regular_file_metadata, resolve_project_path};
 use crate::tools::index_project::load_project_index;
 use crate::tools::steering::{attach_steering, build_steering, take_fallback_candidates};
 
@@ -284,10 +284,13 @@ fn collect_searchable_files(
     {
         let entry = entry?;
         let path = entry.path();
-        if !path.is_file() {
+        if !entry.file_type().is_file() {
             continue;
         }
-        if entry.metadata().map(|m| m.len()).unwrap_or(0) > MAX_FILE_BYTES {
+        let Some(metadata) = regular_file_metadata(path)? else {
+            continue;
+        };
+        if metadata.len() > MAX_FILE_BYTES {
             continue;
         }
         let ext = path.extension().and_then(|ext| ext.to_str()).unwrap_or("");
@@ -413,6 +416,37 @@ mod tests {
             result["matches"][0]["before"][0]["text"],
             json!("fn hello_world() {")
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_search_content_skips_file_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let project_dir = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let outside_file = outside.path().join("secret.rs");
+        std::fs::write(&outside_file, "fn outside_secret() {}\n").unwrap();
+        std::fs::write(project_dir.path().join("lib.rs"), "fn inside() {}\n").unwrap();
+        symlink(&outside_file, project_dir.path().join("linked_secret.rs")).unwrap();
+        let project = setup_indexed_project(&project_dir);
+
+        let result = search_content(SearchContentParams {
+            project,
+            query: "outside_secret".to_string(),
+            regex: None,
+            case_sensitive: None,
+            language: Some("rust".to_string()),
+            file: None,
+            limit: None,
+            offset: None,
+            before_context: None,
+            after_context: None,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(result["count"], json!(0));
     }
 
     #[tokio::test]

--- a/src/tools/search_content.rs
+++ b/src/tools/search_content.rs
@@ -11,7 +11,7 @@ use crate::indexer::{
     default_exclude_patterns, extra_excluded_dir_names, is_declaration_file,
     is_excluded_dir_name_with_custom, is_supported_extension, load_gitignore_patterns,
 };
-use crate::path_policy::{regular_file_metadata, resolve_project_path};
+use crate::path_policy::{read_regular_file, regular_file_metadata, resolve_project_path};
 use crate::tools::index_project::load_project_index;
 use crate::tools::steering::{attach_steering, build_steering, take_fallback_candidates};
 
@@ -101,7 +101,7 @@ pub async fn search_content(params: SearchContentParams) -> anyhow::Result<Value
     let mut truncated = false;
 
     'files: for path in files {
-        let bytes = std::fs::read(&path)
+        let bytes = read_regular_file(&path)
             .with_context(|| format!("Failed to read file: {}", path.display()))?;
         let text = String::from_utf8_lossy(&bytes);
         let lines: Vec<&str> = text.lines().collect();

--- a/src/tools/search_files.rs
+++ b/src/tools/search_files.rs
@@ -13,7 +13,7 @@ use crate::indexer::{
     default_exclude_patterns, extra_excluded_dir_names, is_excluded_dir_name_with_custom,
     load_gitignore_patterns,
 };
-use crate::path_policy::resolve_project_path;
+use crate::path_policy::{regular_file_metadata, resolve_project_path};
 use crate::session;
 use crate::tools::index_project::load_project_index;
 use crate::tools::steering::{attach_steering, build_steering, take_fallback_candidates};
@@ -283,7 +283,7 @@ fn collect_files(
     {
         let entry = entry?;
         let path = entry.path();
-        if !path.is_file() {
+        if !entry.file_type().is_file() || regular_file_metadata(path)?.is_none() {
             continue;
         }
         let rel = path.strip_prefix(root).unwrap_or(path);
@@ -486,6 +486,34 @@ mod tests {
         );
         assert_eq!(result["results"][0]["match_type"], json!("name_substring"));
         assert_eq!(result["results"][0]["path_role"], json!("test"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_search_files_skips_file_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let project_dir = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let outside_file = outside.path().join("SecretFeature.rs");
+        std::fs::write(&outside_file, "fn outside_secret() {}\n").unwrap();
+        std::fs::write(project_dir.path().join("lib.rs"), "fn inside() {}\n").unwrap();
+        symlink(&outside_file, project_dir.path().join("SecretFeature.rs")).unwrap();
+        let project = setup_indexed_project(&project_dir);
+
+        let result = search_files(SearchFilesParams {
+            project,
+            query: "SecretFeature".to_string(),
+            mode: None,
+            language: None,
+            file: None,
+            limit: None,
+            offset: None,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(result["count"], json!(0));
     }
 
     #[tokio::test]

--- a/src/tools/search_symbols.rs
+++ b/src/tools/search_symbols.rs
@@ -790,6 +790,7 @@ mod tests {
     use crate::indexer::language::{Language, Symbol, SymbolKind};
     use crate::indexer::{registry, Indexer};
     use std::path::PathBuf;
+    use std::sync::Arc;
     use tempfile::TempDir;
 
     /// Helper: write a simple Rust file, index it, and save the index to disk.
@@ -820,11 +821,16 @@ mod tests {
     }
 
     fn write_index_with_symbols(dir: &TempDir, symbols: Vec<Symbol>) -> String {
+        let canonical = dir.path().canonicalize().unwrap();
         let mut index = SymbolIndex::new();
-        for symbol in symbols {
+        for mut symbol in symbols {
+            if symbol.file.is_relative() {
+                let file_path = canonical.join(symbol.file.as_ref());
+                std::fs::write(&file_path, format!("pub fn {}() {{}}\n", symbol.name)).unwrap();
+                symbol.file = Arc::new(file_path);
+            }
             index.insert(symbol);
         }
-        let canonical = dir.path().canonicalize().unwrap();
         let idx_dir = index_dir(&canonical).unwrap();
         std::fs::create_dir_all(&idx_dir).unwrap();
         save_index(&index, &idx_dir.join("index.bin")).unwrap();
@@ -1069,11 +1075,14 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(result_a, result_b);
         assert_eq!(result_a["truncated"], json!(false));
         assert_eq!(result_a["count"], json!(2));
+        assert_eq!(result_b["truncated"], json!(false));
+        assert_eq!(result_b["count"], json!(2));
         assert_eq!(result_a["results"][0]["name"], json!("matchBeta"));
         assert_eq!(result_a["results"][1]["name"], json!("matchGamma"));
+        assert_eq!(result_b["results"][0]["name"], json!("matchBeta"));
+        assert_eq!(result_b["results"][1]["name"], json!("matchGamma"));
         assert_eq!(
             result_a["guidance"]["next_step"],
             json!(


### PR DESCRIPTION
## Summary

Reject symlink-backed source files at Pitlane file discovery and read boundaries so a symlink inside an indexed project cannot expose files outside the project root.

## Root Cause

`WalkDir` was configured with `follow_links(false)`, but several downstream checks used `Path::is_file()` or followed metadata calls. Those APIs follow file symlinks, so a file symlink inside an allowed root could be indexed and later read via symbol/content/usages tooling.

## Changes

- Add a shared non-following `regular_file_metadata` helper.
- Use non-following file-type checks in index, content search, file search, usage search, and snapshot code.
- Refuse non-regular files before reading symbol source.
- Filter unsafe or stale symlink-backed symbols when loading an existing index.
- Add Unix regression tests for symlink escape cases.

## Verification

- `cargo fmt --check` passes in the local untrusted Rust container.
- `CARGO_BUILD_JOBS=1 cargo test symlink` passes in the local untrusted Rust container: 6 passed, 0 failed.
- Fork release tag `v0.10.1-codex.1` produced a macOS Apple Silicon artifact from this branch.
- The macOS Apple Silicon artifact was runtime-tested against the symlink escape repro: outside symlink target returned 0 results, inside symbol returned 1 result.
