### PR TITLE
fix(investigate): cache successful answers and allow retries after failure

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -5,10 +5,13 @@ use std::sync::{
     LazyLock, RwLock,
 };
 
+use serde_json::Value;
+
 use crate::sync_utils::{rw_read, rw_write};
 
 const MAX_RECENT_ITEMS: usize = 16;
 const RECENT_QUERY_LIMIT: usize = 12;
+const MAX_INVESTIGATE_CACHE: usize = 8;
 
 #[derive(Default)]
 struct ProjectSessionState {
@@ -18,6 +21,7 @@ struct ProjectSessionState {
     recent_queries: VecDeque<(String, u64)>,
     recent_content: HashMap<String, u64>,
     recent_target_content: HashMap<String, (String, u64)>,
+    investigate_cache: HashMap<String, (Value, u64)>,
 }
 
 pub struct ContentObservation {
@@ -120,6 +124,27 @@ pub fn record_symbols(project: &Path, symbols: impl IntoIterator<Item = (String,
 
 pub fn record_content(project: &Path, namespace: &str, identity: &str, content: &str) -> bool {
     observe_content(project, namespace, identity, content).content_seen
+}
+
+/// Return a cached `investigate` payload for this session, if one exists.
+pub fn get_investigate_cache(project: &Path, cache_key: &str) -> Option<Value> {
+    with_state(project, |state| {
+        state
+            .investigate_cache
+            .get(cache_key)
+            .map(|(response, _)| response.clone())
+    })
+}
+
+/// Store a successful `investigate` payload for repeat lookups in this session.
+pub fn store_investigate_cache(project: &Path, cache_key: &str, response: Value) {
+    let tick = next_tick();
+    with_state_mut(project, |state| {
+        state
+            .investigate_cache
+            .insert(cache_key.to_string(), (response, tick));
+        prune_investigate_cache(state);
+    });
 }
 
 pub fn observe_content(
@@ -275,6 +300,23 @@ fn score_recent(last_seen: Option<u64>, now: u64, base: i32) -> i32 {
     (base - age * 2).max(0)
 }
 
+fn prune_investigate_cache(state: &mut ProjectSessionState) {
+    if state.investigate_cache.len() <= MAX_INVESTIGATE_CACHE {
+        return;
+    }
+    let mut entries: Vec<(String, Value, u64)> = state
+        .investigate_cache
+        .iter()
+        .map(|(k, (response, tick))| (k.clone(), response.clone(), *tick))
+        .collect();
+    entries.sort_by_key(|e| std::cmp::Reverse(e.2));
+    state.investigate_cache = entries
+        .into_iter()
+        .take(MAX_INVESTIGATE_CACHE)
+        .map(|(k, response, tick)| (k, (response, tick)))
+        .collect();
+}
+
 fn prune_recent(state: &mut ProjectSessionState) {
     if state.recent_files.len() > MAX_RECENT_ITEMS {
         let mut entries: Vec<(String, u64)> = state
@@ -414,5 +456,22 @@ mod tests {
         assert!(!has_seen_symbol(&project, "def"));
         assert!(has_seen_file(&project, Path::new("src/lib.rs")));
         assert!(!has_seen_file(&project, Path::new("src/other.rs")));
+    }
+
+    #[test]
+    fn test_investigate_cache_round_trip() {
+        let project = unique_project("session-test-investigate");
+        let key = "investigate:gitignore handling";
+        let payload = serde_json::json!({
+            "query": "how does gitignore work",
+            "answer": "## Investigation",
+            "symbols_read": 2,
+        });
+
+        assert!(get_investigate_cache(&project, key).is_none());
+        store_investigate_cache(&project, key, payload.clone());
+        let cached = get_investigate_cache(&project, key).expect("cached payload");
+        assert_eq!(cached["answer"], payload["answer"]);
+        assert_eq!(cached["symbols_read"], payload["symbols_read"]);
     }
 }

--- a/src/tools/investigate.rs
+++ b/src/tools/investigate.rs
@@ -211,7 +211,30 @@ fn normalize_investigate_key(query: &str) -> String {
     words.sort();
     words.dedup();
     words.truncate(6);
-    words.join(" ")
+    let key = words.join(" ");
+    if key.is_empty() {
+        query.trim().to_lowercase()
+    } else {
+        key
+    }
+}
+
+fn investigate_cache_key(query: &str) -> String {
+    format!("investigate:{}", normalize_investigate_key(query))
+}
+
+fn mark_investigate_repeated(mut response: Value) -> Value {
+    if let Some(obj) = response.as_object_mut() {
+        obj.insert("repeated".to_string(), json!(true));
+        obj.insert(
+            "guidance".to_string(),
+            json!(
+                "Returning the cached investigation from this session. \
+                 Use read_code_unit(symbol_id=...) if you need more detail on a specific symbol."
+            ),
+        );
+    }
+    response
 }
 
 pub async fn investigate(params: InvestigateParams) -> anyhow::Result<Value> {
@@ -221,21 +244,9 @@ pub async fn investigate(params: InvestigateParams) -> anyhow::Result<Value> {
         return Err(anyhow::anyhow!("query must not be empty"));
     }
 
-    // Check if a similar question was already investigated in this session.
-    // Normalize the key to catch rephrased queries.
-    let normalized_key = normalize_investigate_key(&query);
-    let investigate_key = format!("investigate:{}", normalized_key);
-    let observation = session::observe_content(&canonical, "investigate", &investigate_key, &query);
-    if observation.content_seen {
-        return Ok(json!({
-            "query": query,
-            "answer": "You already investigated a similar question. \
-                 Use the previous answer. Do NOT call investigate again. \
-                 If you need a specific symbol, use read_code_unit(symbol_id=...) directly.",
-            "symbols_read": 0,
-            "files_covered": 0,
-            "repeated": true,
-        }));
+    let cache_key = investigate_cache_key(&query);
+    if let Some(cached) = session::get_investigate_cache(&canonical, &cache_key) {
+        return Ok(mark_investigate_repeated(cached));
     }
 
     let index = load_project_index(&params.project)?;
@@ -544,10 +555,117 @@ pub async fn investigate(params: InvestigateParams) -> anyhow::Result<Value> {
 
     session::record_query(&canonical, &query);
 
-    Ok(json!({
+    let response = json!({
         "query": query,
         "answer": answer,
         "symbols_read": symbols_seen.len(),
         "files_covered": files_seen.len(),
-    }))
+        "repeated": false,
+    });
+    session::store_investigate_cache(&canonical, &cache_key, response.clone());
+
+    Ok(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tools::index_project::{index_project, IndexProjectParams};
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_normalize_investigate_key_dedupes_rephrasings() {
+        let a = normalize_investigate_key("How does gitignore handling work?");
+        let b = normalize_investigate_key("gitignore handling work");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_normalize_investigate_key_falls_back_to_raw_query() {
+        let key = normalize_investigate_key("how to");
+        assert_eq!(key, "how to");
+    }
+
+    async fn setup_project(dir: &TempDir) -> String {
+        let project = dir.path().to_string_lossy().to_string();
+        index_project(IndexProjectParams {
+            path: project.clone(),
+            exclude: None,
+            force: Some(true),
+            max_files: None,
+            progress_token: None,
+            peer: None,
+            embed_config: None,
+        })
+        .await
+        .unwrap();
+        project
+    }
+
+    #[tokio::test]
+    async fn test_investigate_repeat_returns_cached_answer() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("lib.rs"),
+            "pub fn gitignore_match() {}\npub fn other() {}\n",
+        )
+        .unwrap();
+        let project = setup_project(&dir).await;
+
+        let first = investigate(InvestigateParams {
+            project: project.clone(),
+            query: "gitignore_match".to_string(),
+            language: None,
+            scope: None,
+        })
+        .await
+        .unwrap();
+        assert_eq!(first["repeated"], json!(false));
+        assert!(first["answer"]
+            .as_str()
+            .unwrap()
+            .contains("gitignore_match"));
+
+        let second = investigate(InvestigateParams {
+            project,
+            query: "find gitignore_match".to_string(),
+            language: None,
+            scope: None,
+        })
+        .await
+        .unwrap();
+        assert_eq!(second["repeated"], json!(true));
+        assert_eq!(second["answer"], first["answer"]);
+        assert_eq!(second["symbols_read"], first["symbols_read"]);
+        assert!(second["guidance"].as_str().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_investigate_failure_does_not_block_retry() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("lib.rs"), "pub fn hello() {}\n").unwrap();
+        let project = dir.path().to_string_lossy().to_string();
+
+        let err = investigate(InvestigateParams {
+            project: project.clone(),
+            query: "hello".to_string(),
+            language: None,
+            scope: None,
+        })
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("indexed"));
+
+        let ready = setup_project(&dir).await;
+        let ok = investigate(InvestigateParams {
+            project: ready,
+            query: "hello".to_string(),
+            language: None,
+            scope: None,
+        })
+        .await
+        .unwrap();
+        assert_eq!(ok["repeated"], json!(false));
+        assert!(ok["symbols_read"].as_u64().unwrap_or(0) > 0);
+    }
 }


### PR DESCRIPTION
Return the full cached investigation on repeated similar queries instead of an empty stub, and only record results after a successful run so failed calls can be retried once the project is indexed.