### PR TITLE
feat: support external embedding endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1122,6 +1132,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1639,6 +1650,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "ordered-float"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,6 +2103,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2196,6 +2214,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,6 +2280,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2280,6 +2319,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ tantivy = "0.26"
 reqwest = { version = "0.12", default-features = false, features = [
     "json",
     "rustls-tls",
+    "rustls-tls-native-roots",
 ] }
 futures = "0.3"
 tree-sitter-solidity = "1.2"

--- a/SEMANTIC_SEARCH.md
+++ b/SEMANTIC_SEARCH.md
@@ -2,21 +2,13 @@
 
 Semantic search lets you find symbols by meaning rather than by name. Instead of matching keywords, pitlane-mcp generates embedding vectors for every indexed symbol and ranks results by cosine similarity to your query.
 
-> **Experimental:** This feature requires a locally-running embedding server and adds significant indexing time for large codebases. The API and behaviour may change in future releases.
+> **Experimental:** This feature requires a reachable embedding server and adds significant indexing time for large codebases. The API and behaviour may change in future releases.
 
 ## How It Works
 
 When `PITLANE_EMBED_URL` and `PITLANE_EMBED_MODEL` are set, `index_project` generates an embedding vector for every symbol and stores them in `embeddings.bin` alongside the regular index. Subsequent `search_symbols` calls with `"mode": "semantic"` embed the query and return symbols ranked by cosine similarity.
 
 When the env vars are absent, pitlane-mcp behaves exactly as before — zero overhead, zero network calls.
-
-## Prerequisites
-
-Install [Ollama](https://ollama.com) and pull an embedding model:
-
-```bash
-ollama pull nomic-embed-text
-```
 
 ## Quick Start
 
@@ -40,10 +32,29 @@ pitlane search /your/project "error handling when file cannot be read" --mode se
 |---|---|---|---|
 | `PITLANE_EMBED_URL` | yes | — | Full URL of the embedding endpoint (e.g. `http://localhost:11434/api/embed`) |
 | `PITLANE_EMBED_MODEL` | yes | — | Model identifier to pass in requests (e.g. `nomic-embed-text`) |
+| `PITLANE_EMBED_API_KEY` | no | — | Bearer token sent as `Authorization: Bearer ...` |
+| `PITLANE_EMBED_HEADERS` | no | — | JSON object of additional string request headers, such as `{"x-tenant-id":"engineering"}` |
 | `PITLANE_EMBED_BATCH_SIZE` | no | `256` | Number of symbols per HTTP request. Reduce for large/slow models. |
 | `PITLANE_EMBED_TIMEOUT` | no | `120` | Per-request timeout in seconds. Increase for large models. |
+| `PITLANE_EMBED_MAX_CONCURRENCY` | no | `16` | Maximum number of concurrent embedding requests. Reduce for rate-limited gateways. |
+| `PITLANE_EMBED_MAX_RETRIES` | no | `3` | Retries for `429` and transient `5xx` responses. |
+| `PITLANE_EMBED_RETRY_BASE_MS` | no | `500` | Initial exponential-backoff delay when `Retry-After` is absent. |
 
 Both `PITLANE_EMBED_URL` and `PITLANE_EMBED_MODEL` must be set to non-empty strings for embeddings to be enabled. Either absent or empty disables the feature entirely.
+
+`PITLANE_EMBED_URL` may point to a local server or an external OpenAI-compatible endpoint. External endpoints should accept the standard `model` and `input` request fields and return `data[i].embedding` responses. Keep credentials in environment variables rather than putting them in the endpoint URL.
+
+HTTPS connections trust both public WebPKI roots and certificates installed in
+the operating system's native trust store, including company-internal CAs.
+
+```bash
+export PITLANE_EMBED_URL=https://embeddings.company.example/v1/embeddings
+export PITLANE_EMBED_MODEL=company-code-embedding
+export PITLANE_EMBED_API_KEY="$COMPANY_EMBEDDING_TOKEN"
+export PITLANE_EMBED_HEADERS='{"x-tenant-id":"engineering"}'
+export PITLANE_EMBED_MAX_CONCURRENCY=4
+export PITLANE_EMBED_MAX_RETRIES=5
+```
 
 ## Model Recommendations
 
@@ -129,7 +140,7 @@ Environment="OLLAMA_MAX_QUEUE=512"
 - **Indexing speed** — embedding generation is bottlenecked by the Ollama HTTP API, not by GPU compute. Each request has fixed overhead regardless of batch size. This is a fundamental limitation of the HTTP interface.
 - **Model switching** — switching models invalidates all stored embeddings. Re-index with `--force` after changing `PITLANE_EMBED_MODEL`.
 - **Dimension mismatch** — if the embedding model changes dimension (e.g. switching from nomic to qwen3), semantic search returns an error until you re-index with `--force`.
-- **Connection errors** — Ollama may drop connections under heavy load. Affected symbols are skipped and reported in `embeddings_skipped`. Re-run without `--force` to fill in the gaps.
+- **Connection and gateway errors** — Affected symbols are skipped and reported in `embeddings_skipped`. Re-run without `--force` to fill in the gaps. Reduce `PITLANE_EMBED_MAX_CONCURRENCY` for rate-limited external gateways.
 - **Large codebases** — the Linux kernel (~311k symbols) takes ~26 minutes with nomic-embed-text. Consider filtering to specific subdirectories for very large repos.
 
 ## LLM Usage Guide

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -11,8 +11,11 @@ documentation.
 documents, calls the configured OpenAI/Ollama-compatible embedding endpoint,
 L2-normalizes every returned vector, validates dimensions, and stores vectors by
 stable symbol ID in `embeddings.bin`. `embeddings.meta.json` records the model,
-dimension, document format, size settings, and query/document prefixes. A change
-to any of these invalidates the cache and causes a rebuild.
+endpoint identity, dimension, document format, size settings, and
+query/document prefixes. A change to any of these invalidates the cache and
+causes a rebuild. Credential header values are deliberately excluded from cache
+identity, so rotating credentials does not rebuild vectors. Non-secret routing
+headers, such as tenant identifiers, are included.
 
 The default `metadata_code` document includes relative file path, name,
 qualified name, kind, language, signature, documentation, identifiers extracted
@@ -41,12 +44,25 @@ uses the same search path before reading source.
 - `PITLANE_EMBED_MAX_IDENTIFIERS` (default `64`)
 - `PITLANE_EMBED_TASK_PREFIX_MODE=auto|none|nomic`
 - `PITLANE_EMBED_DOCUMENT_PREFIX` and `PITLANE_EMBED_QUERY_PREFIX` override task prefixes
+- `PITLANE_EMBED_API_KEY` adds an `Authorization: Bearer ...` header
+- `PITLANE_EMBED_HEADERS` adds arbitrary request headers from a JSON object of string values
+- `PITLANE_EMBED_MAX_CONCURRENCY` limits concurrent endpoint requests (default `16`)
+- `PITLANE_EMBED_MAX_RETRIES` retries `429` and transient `5xx` responses (default `3`)
+- `PITLANE_EMBED_RETRY_BASE_MS` sets exponential backoff when `Retry-After` is absent (default `500`)
 - `PITLANE_SEMANTIC_LEXICAL_WEIGHT` (default `0.10`)
 - `PITLANE_SEMANTIC_BM25_WEIGHT` (default `0.03`)
 - `PITLANE_SEMANTIC_TEST_PENALTY` (default `0.12`)
 - `PITLANE_SEMANTIC_AUXILIARY_PENALTY` (default `0.03`)
 - `PITLANE_SEMANTIC_KIND_WEIGHT` (default `0.01`)
 - `PITLANE_SEMANTIC_SESSION_WEIGHT` (default `0`)
+
+`PITLANE_EMBED_URL` can target any reachable OpenAI-compatible embedding endpoint,
+including company gateways. The endpoint must accept `model` and `input` fields
+and return `data[i].embedding`. Credentials are sent through environment-backed
+headers. Credential values are never included in embedding cache identity.
+
+HTTPS requests trust both public WebPKI roots and certificates installed in the
+operating system's native trust store, including company-internal CAs.
 
 ## llama.cpp benchmark
 

--- a/src/bin/pitlane.rs
+++ b/src/bin/pitlane.rs
@@ -254,7 +254,7 @@ async fn main() -> anyhow::Result<()> {
 
     match cli.command {
         Command::Watch { project } => {
-            let embed_config = pitlane_mcp::embed::EmbedConfig::from_env().map(Arc::new);
+            let embed_config = pitlane_mcp::embed::EmbedConfig::try_from_env()?.map(Arc::new);
             let registry = tools::watch_project::WatcherRegistry::new();
             let params = tools::watch_project::WatchProjectParams {
                 project: project.clone(),
@@ -284,7 +284,7 @@ async fn run_command(command: Command) -> anyhow::Result<serde_json::Value> {
             exclude,
             max_files,
         } => {
-            let embed_config = pitlane_mcp::embed::EmbedConfig::from_env();
+            let embed_config = pitlane_mcp::embed::EmbedConfig::try_from_env()?;
 
             // Pass embed_config=None so index_project doesn't spawn a background
             // embedding task that would be killed when the CLI process exits.
@@ -354,7 +354,8 @@ async fn run_command(command: Command) -> anyhow::Result<serde_json::Value> {
             offset,
             mode,
         } => {
-            let embed_config = pitlane_mcp::embed::EmbedConfig::from_env().map(std::sync::Arc::new);
+            let embed_config =
+                pitlane_mcp::embed::EmbedConfig::try_from_env()?.map(std::sync::Arc::new);
             let params = tools::search_symbols::SearchSymbolsParams {
                 project,
                 query,
@@ -476,7 +477,7 @@ async fn run_command(command: Command) -> anyhow::Result<serde_json::Value> {
             poll_interval_ms,
             timeout_secs,
         } => {
-            let embed_config = pitlane_mcp::embed::EmbedConfig::from_env().map(Arc::new);
+            let embed_config = pitlane_mcp::embed::EmbedConfig::try_from_env()?.map(Arc::new);
             let params = tools::wait_for_embeddings::WaitForEmbeddingsParams {
                 project,
                 poll_interval_ms,

--- a/src/embed/client.rs
+++ b/src/embed/client.rs
@@ -8,6 +8,17 @@ use super::EmbedConfig;
 
 pub const MAX_CONCURRENCY: usize = 16;
 pub const BATCH_SIZE: usize = 256;
+pub const MAX_RETRIES: usize = 3;
+pub const RETRY_BASE_MS: u64 = 500;
+
+/// Returns the effective concurrent request limit.
+pub fn effective_max_concurrency() -> usize {
+    std::env::var("PITLANE_EMBED_MAX_CONCURRENCY")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(MAX_CONCURRENCY)
+}
 
 /// Returns the effective batch size, respecting `PITLANE_EMBED_BATCH_SIZE` if set.
 pub fn effective_batch_size() -> usize {
@@ -16,6 +27,21 @@ pub fn effective_batch_size() -> usize {
         .and_then(|v| v.parse::<usize>().ok())
         .filter(|&n| n > 0)
         .unwrap_or(BATCH_SIZE)
+}
+
+/// Returns the number of retries for rate-limit and transient server errors.
+pub fn effective_max_retries() -> usize {
+    std::env::var("PITLANE_EMBED_MAX_RETRIES")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(MAX_RETRIES)
+}
+
+fn effective_retry_base_ms() -> u64 {
+    std::env::var("PITLANE_EMBED_RETRY_BASE_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(RETRY_BASE_MS)
 }
 
 // ── HTTP request types ────────────────────────────────────────────────────────
@@ -53,6 +79,7 @@ impl EmbedClient {
         // the first one (::1) is refused, causing all requests to fail.
         let mut builder =
             reqwest::ClientBuilder::new().timeout(std::time::Duration::from_secs(timeout_secs));
+        builder = builder.default_headers(config.headers.clone());
 
         if let Ok(url) = reqwest::Url::parse(&config.url) {
             if url.host_str() == Some("localhost") {
@@ -78,23 +105,21 @@ impl EmbedClient {
             input: EmbedInput::Batch(prepared.iter().map(|s| s.as_str()).collect()),
         };
 
-        let response = match self
-            .http
-            .post(&self.config.url)
-            .header("Content-Type", "application/json")
-            .json(&body)
-            .send()
-            .await
-        {
+        let response = match self.send_with_retry(&body).await {
             Ok(r) => r,
             Err(e) => {
-                tracing::warn!("embed_batch: connection error: {e}");
+                tracing::warn!(error = ?e, "embed_batch: connection error");
                 return vec![None; n];
             }
         };
 
         if !response.status().is_success() {
-            tracing::warn!("embed_batch: HTTP error {}", response.status());
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            tracing::warn!(
+                "embed_batch: HTTP error {status}: {}",
+                truncate_error_body(&body)
+            );
             return vec![None; n];
         }
 
@@ -118,15 +143,17 @@ impl EmbedClient {
         };
 
         let response = self
-            .http
-            .post(&self.config.url)
-            .header("Content-Type", "application/json")
-            .json(&body)
-            .send()
-            .await?;
+            .send_with_retry(&body)
+            .await
+            .map_err(|err| anyhow::anyhow!("embed_query: connection error: {err:?}"))?;
 
         if !response.status().is_success() {
-            anyhow::bail!("embed_query: HTTP error {}", response.status());
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "embed_query: HTTP error {status}: {}",
+                truncate_error_body(&body)
+            );
         }
 
         let json: serde_json::Value = response.json().await?;
@@ -187,6 +214,94 @@ impl EmbedClient {
             "embed_query: response has neither 'data', 'embeddings', nor 'embedding' field"
         )
     }
+
+    async fn send_with_retry(
+        &self,
+        body: &EmbedRequest<'_>,
+    ) -> Result<reqwest::Response, reqwest::Error> {
+        let max_retries = effective_max_retries();
+
+        for attempt in 0..=max_retries {
+            let response = self
+                .http
+                .post(&self.config.url)
+                .header("Content-Type", "application/json")
+                .json(body)
+                .send()
+                .await;
+
+            match response {
+                Ok(response) if is_retryable_status(response.status()) && attempt < max_retries => {
+                    let status = response.status();
+                    let delay = retry_delay(&response, attempt);
+                    let _ = response.bytes().await;
+                    tracing::warn!(
+                        %status,
+                        attempt = attempt + 1,
+                        max_retries,
+                        delay_ms = delay.as_millis() as u64,
+                        "embedding request is rate-limited or temporarily unavailable; retrying"
+                    );
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
+                Ok(response) => return Ok(response),
+                Err(error) if attempt < max_retries => {
+                    let delay = exponential_retry_delay(attempt);
+                    tracing::warn!(
+                        error = ?error,
+                        attempt = attempt + 1,
+                        max_retries,
+                        delay_ms = delay.as_millis() as u64,
+                        "embedding request failed; retrying"
+                    );
+                    tokio::time::sleep(delay).await;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+
+        unreachable!("embedding retry loop always returns a response or error")
+    }
+}
+
+fn is_retryable_status(status: reqwest::StatusCode) -> bool {
+    status == reqwest::StatusCode::TOO_MANY_REQUESTS
+        || status == reqwest::StatusCode::INTERNAL_SERVER_ERROR
+        || status == reqwest::StatusCode::BAD_GATEWAY
+        || status == reqwest::StatusCode::SERVICE_UNAVAILABLE
+        || status == reqwest::StatusCode::GATEWAY_TIMEOUT
+}
+
+fn retry_delay(response: &reqwest::Response, attempt: usize) -> std::time::Duration {
+    response
+        .headers()
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(std::time::Duration::from_secs)
+        .unwrap_or_else(|| exponential_retry_delay(attempt))
+}
+
+fn exponential_retry_delay(attempt: usize) -> std::time::Duration {
+    let multiplier = 1u64 << attempt.min(6);
+    std::time::Duration::from_millis(
+        effective_retry_base_ms()
+            .saturating_mul(multiplier)
+            .min(30_000),
+    )
+}
+
+fn truncate_error_body(body: &str) -> String {
+    const MAX_ERROR_BODY_CHARS: usize = 512;
+    let body = body.trim();
+    if body.chars().count() <= MAX_ERROR_BODY_CHARS {
+        return body.to_string();
+    }
+    format!(
+        "{}...",
+        body.chars().take(MAX_ERROR_BODY_CHARS).collect::<String>()
+    )
 }
 
 /// Cosine similarity between two unit-normalised vectors (dot product).
@@ -299,7 +414,71 @@ mod tests {
     use proptest::collection::vec as pvec;
     use proptest::num::f32::NORMAL;
     use proptest::prelude::*;
+    use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
     use std::collections::HashMap;
+
+    #[tokio::test]
+    async fn sends_configured_headers_for_batch_and_query() {
+        use httpmock::prelude::*;
+
+        let server = MockServer::start();
+        let embedding = serde_json::json!({
+            "data": [
+                { "index": 0, "embedding": [1.0, 0.0] },
+                { "index": 1, "embedding": [0.0, 1.0] }
+            ]
+        });
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .header("authorization", "Bearer test-token")
+                .header("x-tenant-id", "engineering");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(embedding);
+        });
+
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer test-token"));
+        headers.insert("x-tenant-id", HeaderValue::from_static("engineering"));
+        let client = EmbedClient::new(Arc::new(EmbedConfig {
+            url: server.url("/v1/embeddings"),
+            model: "company-code-embedding".to_string(),
+            headers,
+        }));
+
+        let batch = client
+            .embed_batch(&["first".to_string(), "second".to_string()])
+            .await;
+        assert_eq!(batch.iter().filter(|item| item.is_some()).count(), 2);
+
+        let query = client.embed_query("find retries").await.unwrap();
+        assert_eq!(query.len(), 2);
+        assert_eq!(mock.calls(), 2);
+    }
+
+    #[tokio::test]
+    async fn retries_rate_limited_batch_using_retry_after() {
+        use httpmock::prelude::*;
+
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(POST);
+            then.status(429)
+                .header("retry-after", "0")
+                .body(r#"{"error":"rate limited"}"#);
+        });
+
+        let client = EmbedClient::new(Arc::new(EmbedConfig {
+            url: server.url("/v1/embeddings"),
+            model: "test-model".to_string(),
+            headers: HeaderMap::new(),
+        }));
+
+        let result = client.embed_batch(&["rate limited".to_string()]).await;
+
+        assert_eq!(result, vec![None]);
+        mock.assert_calls(effective_max_retries() + 1);
+    }
 
     #[test]
     fn openai_response_respects_explicit_indices() {

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -8,11 +8,12 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use futures::StreamExt;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, AUTHORIZATION};
 
 use crate::index::SymbolIndex;
 use crate::indexer::language::{Symbol, SymbolId};
 
-use client::{effective_batch_size, EmbedClient, MAX_CONCURRENCY};
+use client::{effective_batch_size, effective_max_concurrency, EmbedClient};
 use store::{EmbedStore, EmbedStoreMetadata};
 
 /// Result returned by `generate_embeddings` and `update_embeddings_for_files`.
@@ -36,22 +37,111 @@ pub fn symbol_text(sym: &Symbol) -> String {
 pub struct EmbedConfig {
     pub url: String,
     pub model: String,
+    pub headers: HeaderMap,
 }
 
 impl EmbedConfig {
-    /// Returns `Some(config)` when both `PITLANE_EMBED_URL` and
-    /// `PITLANE_EMBED_MODEL` are set to non-empty strings, `None` otherwise.
-    pub fn from_env() -> Option<Self> {
-        let url = std::env::var("PITLANE_EMBED_URL").ok()?;
-        if url.is_empty() {
-            return None;
+    /// Parse embedding configuration and return an error for invalid headers.
+    pub fn try_from_env() -> anyhow::Result<Option<Self>> {
+        let url = match std::env::var("PITLANE_EMBED_URL") {
+            Ok(url) if !url.is_empty() => url,
+            _ => return Ok(None),
+        };
+        let model = match std::env::var("PITLANE_EMBED_MODEL") {
+            Ok(model) if !model.is_empty() => model,
+            _ => return Ok(None),
+        };
+
+        let mut headers = HeaderMap::new();
+        if let Ok(raw_headers) = std::env::var("PITLANE_EMBED_HEADERS") {
+            if !raw_headers.trim().is_empty() {
+                let values: serde_json::Map<String, serde_json::Value> =
+                    serde_json::from_str(&raw_headers).map_err(|err| {
+                        anyhow::anyhow!(
+                            "PITLANE_EMBED_HEADERS must be a JSON object of string values: {err}"
+                        )
+                    })?;
+
+                for (name, value) in values {
+                    let value = value.as_str().ok_or_else(|| {
+                        anyhow::anyhow!("PITLANE_EMBED_HEADERS value for '{name}' must be a string")
+                    })?;
+                    let name = HeaderName::from_bytes(name.as_bytes())
+                        .map_err(|err| anyhow::anyhow!("invalid embedding header name: {err}"))?;
+                    let value = HeaderValue::from_str(value).map_err(|err| {
+                        anyhow::anyhow!("invalid value for embedding header: {err}")
+                    })?;
+                    headers.insert(name, value);
+                }
+            }
         }
-        let model = std::env::var("PITLANE_EMBED_MODEL").ok()?;
-        if model.is_empty() {
-            return None;
+
+        if let Ok(api_key) = std::env::var("PITLANE_EMBED_API_KEY") {
+            if !api_key.is_empty() {
+                if headers.contains_key(AUTHORIZATION) {
+                    anyhow::bail!(
+                        "PITLANE_EMBED_API_KEY cannot be combined with an Authorization header in PITLANE_EMBED_HEADERS"
+                    );
+                }
+                let value = HeaderValue::from_str(&format!("Bearer {api_key}"))
+                    .map_err(|err| anyhow::anyhow!("invalid embedding API key: {err}"))?;
+                headers.insert(AUTHORIZATION, value);
+            }
         }
-        Some(Self { url, model })
+
+        Ok(Some(Self {
+            url,
+            model,
+            headers,
+        }))
     }
+
+    /// Returns `Some(config)` when configured, `None` when embeddings are
+    /// disabled. Invalid header configuration is logged and also disables
+    /// embeddings for callers that cannot propagate startup errors.
+    pub fn from_env() -> Option<Self> {
+        match Self::try_from_env() {
+            Ok(config) => config,
+            Err(err) => {
+                tracing::error!("invalid embedding configuration: {err}");
+                None
+            }
+        }
+    }
+}
+
+/// Stable identity for the configured embedding endpoint.
+///
+/// Header values that look like credentials are represented only by their
+/// names, so rotating a token does not rebuild vectors. Non-secret routing
+/// headers, such as a tenant identifier, remain part of cache identity.
+pub fn endpoint_fingerprint(url: &str, headers: &HeaderMap) -> String {
+    let mut identity = format!("url={url}\n");
+    let mut header_identity: Vec<String> = headers
+        .iter()
+        .map(|(name, value)| {
+            let name = name.as_str().to_ascii_lowercase();
+            let value = if is_credential_header(&name) {
+                "<credential>".to_string()
+            } else {
+                value
+                    .to_str()
+                    .map(ToOwned::to_owned)
+                    .unwrap_or_else(|_| "<binary>".to_string())
+            };
+            format!("{name}={value}")
+        })
+        .collect();
+    header_identity.sort();
+    identity.push_str(&header_identity.join("\n"));
+    blake3::hash(identity.as_bytes()).to_hex().to_string()
+}
+
+fn is_credential_header(name: &str) -> bool {
+    name == "authorization"
+        || name.contains("api-key")
+        || name.contains("token")
+        || name.contains("secret")
 }
 
 /// Generate embeddings for all symbols in `index` and save to `store_path`.
@@ -78,7 +168,13 @@ pub async fn generate_embeddings(
     let compatible = EmbedStoreMetadata::load(store_path)
         .ok()
         .flatten()
-        .is_some_and(|meta| meta.is_compatible(&config.model, &fingerprint));
+        .is_some_and(|meta| {
+            meta.is_compatible(
+                &config.model,
+                &fingerprint,
+                &endpoint_fingerprint(&config.url, &config.headers),
+            )
+        });
 
     // Model, prefix, or document changes must never reuse stale vectors.
     if force || !compatible {
@@ -110,6 +206,7 @@ pub async fn generate_embeddings(
         let client = Arc::new(EmbedClient::new(Arc::new(EmbedConfig {
             url: config.url.clone(),
             model: config.model.clone(),
+            headers: config.headers.clone(),
         })));
 
         // 4. Chunk into batch slices (size configurable via PITLANE_EMBED_BATCH_SIZE)
@@ -147,7 +244,8 @@ pub async fn generate_embeddings(
         });
 
         let mut completed_symbols = 0usize;
-        let mut stream = futures::stream::iter(chunk_futures).buffer_unordered(MAX_CONCURRENCY);
+        let mut stream =
+            futures::stream::iter(chunk_futures).buffer_unordered(effective_max_concurrency());
 
         while let Some((chunk_idx, batch)) = stream.next().await {
             let batch_size = batch.len();
@@ -207,6 +305,7 @@ pub async fn generate_embeddings(
             model: config.model.clone(),
             dimension: store.dimension().unwrap_or(0),
             document_fingerprint: fingerprint,
+            endpoint_fingerprint: endpoint_fingerprint(&config.url, &config.headers),
         }
         .save(store_path)
     }) {
@@ -252,7 +351,13 @@ pub async fn update_embeddings_for_files(
     let compatible = EmbedStoreMetadata::load(store_path)
         .ok()
         .flatten()
-        .is_some_and(|meta| meta.is_compatible(&config.model, &fingerprint));
+        .is_some_and(|meta| {
+            meta.is_compatible(
+                &config.model,
+                &fingerprint,
+                &endpoint_fingerprint(&config.url, &config.headers),
+            )
+        });
     if !compatible {
         store = EmbedStore::new();
     }
@@ -272,6 +377,7 @@ pub async fn update_embeddings_for_files(
         let client = Arc::new(EmbedClient::new(Arc::new(EmbedConfig {
             url: config.url.clone(),
             model: config.model.clone(),
+            headers: config.headers.clone(),
         })));
 
         // 4. Chunk into batch slices and dispatch via buffer_unordered
@@ -296,7 +402,7 @@ pub async fn update_embeddings_for_files(
         });
 
         let results: Vec<Vec<(String, Option<Vec<f32>>)>> = futures::stream::iter(chunk_futures)
-            .buffer_unordered(MAX_CONCURRENCY)
+            .buffer_unordered(effective_max_concurrency())
             .collect()
             .await;
 
@@ -322,6 +428,7 @@ pub async fn update_embeddings_for_files(
             model: config.model.clone(),
             dimension: store.dimension().unwrap_or(0),
             document_fingerprint: fingerprint,
+            endpoint_fingerprint: endpoint_fingerprint(&config.url, &config.headers),
         }
         .save(store_path)
     }) {
@@ -376,6 +483,7 @@ mod tests {
         let embed_config = Some(Arc::new(EmbedConfig {
             url: server.url("/"),
             model: "test".to_string(),
+            headers: HeaderMap::new(),
         }));
 
         // Call index_project with embeddings enabled
@@ -480,6 +588,7 @@ mod tests {
         let embed_config = Some(Arc::new(EmbedConfig {
             url: server.url("/"),
             model: "test".to_string(),
+            headers: HeaderMap::new(),
         }));
 
         // First call: force=true — must embed all symbols
@@ -613,6 +722,7 @@ mod tests {
         let config = EmbedConfig {
             url: server.url("/"),
             model: "test".to_string(),
+            headers: HeaderMap::new(),
         };
 
         // changed_files = {file_a}, removed_ids = ["sym_removed"]
@@ -831,6 +941,103 @@ mod tests {
         );
     }
 
+    #[test]
+    fn parses_bearer_and_arbitrary_headers() {
+        with_env(
+            &[
+                (
+                    "PITLANE_EMBED_URL",
+                    Some("https://embed.example/v1/embeddings"),
+                ),
+                ("PITLANE_EMBED_MODEL", Some("company-code-embedding")),
+                ("PITLANE_EMBED_API_KEY", Some("secret-token")),
+                (
+                    "PITLANE_EMBED_HEADERS",
+                    Some(r#"{"x-tenant-id":"engineering","x-region":"us"}"#),
+                ),
+            ],
+            || {
+                let config = EmbedConfig::try_from_env()
+                    .unwrap()
+                    .expect("embedding config should be enabled");
+                assert_eq!(config.headers[AUTHORIZATION], "Bearer secret-token");
+                assert_eq!(config.headers["x-tenant-id"], "engineering");
+                assert_eq!(config.headers["x-region"], "us");
+            },
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_headers() {
+        with_env(
+            &[
+                (
+                    "PITLANE_EMBED_URL",
+                    Some("https://embed.example/v1/embeddings"),
+                ),
+                ("PITLANE_EMBED_MODEL", Some("company-code-embedding")),
+                ("PITLANE_EMBED_API_KEY", None),
+                ("PITLANE_EMBED_HEADERS", Some("not-json")),
+            ],
+            || {
+                let error = match EmbedConfig::try_from_env() {
+                    Ok(_) => panic!("malformed headers should be rejected"),
+                    Err(error) => error,
+                };
+                assert!(error.to_string().contains("PITLANE_EMBED_HEADERS"));
+            },
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_authorization_configuration() {
+        with_env(
+            &[
+                (
+                    "PITLANE_EMBED_URL",
+                    Some("https://embed.example/v1/embeddings"),
+                ),
+                ("PITLANE_EMBED_MODEL", Some("company-code-embedding")),
+                ("PITLANE_EMBED_API_KEY", Some("secret-token")),
+                (
+                    "PITLANE_EMBED_HEADERS",
+                    Some(r#"{"Authorization":"Bearer another-token"}"#),
+                ),
+            ],
+            || {
+                let error = match EmbedConfig::try_from_env() {
+                    Ok(_) => panic!("duplicate authorization should be rejected"),
+                    Err(error) => error,
+                };
+                assert!(error.to_string().contains("cannot be combined"));
+            },
+        );
+    }
+
+    #[test]
+    fn endpoint_identity_excludes_credentials_but_includes_routing_headers() {
+        let mut first = HeaderMap::new();
+        first.insert(AUTHORIZATION, HeaderValue::from_static("Bearer first"));
+        first.insert("x-tenant-id", HeaderValue::from_static("engineering"));
+
+        let mut rotated = HeaderMap::new();
+        rotated.insert(AUTHORIZATION, HeaderValue::from_static("Bearer rotated"));
+        rotated.insert("x-tenant-id", HeaderValue::from_static("engineering"));
+
+        let mut different_tenant = HeaderMap::new();
+        different_tenant.insert(AUTHORIZATION, HeaderValue::from_static("Bearer first"));
+        different_tenant.insert("x-tenant-id", HeaderValue::from_static("research"));
+
+        assert_eq!(
+            endpoint_fingerprint("https://embed.example/v1/embeddings", &first),
+            endpoint_fingerprint("https://embed.example/v1/embeddings", &rotated)
+        );
+        assert_ne!(
+            endpoint_fingerprint("https://embed.example/v1/embeddings", &first),
+            endpoint_fingerprint("https://embed.example/v1/embeddings", &different_tenant)
+        );
+    }
+
     // Feature: ollama-lmstudio-embeddings, Property 3: Batch count equals ceil(N / BATCH_SIZE)
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(50))]
@@ -882,6 +1089,7 @@ mod tests {
             let config = EmbedConfig {
                 url: server.url("/"),
                 model: "test-model".to_string(),
+                headers: HeaderMap::new(),
             };
 
             let dir = tempdir().expect("tempdir");

--- a/src/embed/store.rs
+++ b/src/embed/store.rs
@@ -11,6 +11,7 @@ pub struct EmbedStoreMetadata {
     pub model: String,
     pub dimension: usize,
     pub document_fingerprint: String,
+    pub endpoint_fingerprint: String,
 }
 
 impl EmbedStoreMetadata {
@@ -34,10 +35,16 @@ impl EmbedStoreMetadata {
         Ok(())
     }
 
-    pub fn is_compatible(&self, model: &str, fingerprint: &str) -> bool {
+    pub fn is_compatible(
+        &self,
+        model: &str,
+        fingerprint: &str,
+        endpoint_fingerprint: &str,
+    ) -> bool {
         self.format_version == crate::embed::document::DOCUMENT_FORMAT_VERSION
             && self.model == model
             && self.document_fingerprint == fingerprint
+            && self.endpoint_fingerprint == endpoint_fingerprint
     }
 }
 
@@ -138,10 +145,12 @@ mod tests {
             model: "model-a".into(),
             dimension: 768,
             document_fingerprint: "profile-a".into(),
+            endpoint_fingerprint: "endpoint-a".into(),
         };
-        assert!(metadata.is_compatible("model-a", "profile-a"));
-        assert!(!metadata.is_compatible("model-b", "profile-a"));
-        assert!(!metadata.is_compatible("model-a", "profile-b"));
+        assert!(metadata.is_compatible("model-a", "profile-a", "endpoint-a"));
+        assert!(!metadata.is_compatible("model-b", "profile-a", "endpoint-a"));
+        assert!(!metadata.is_compatible("model-a", "profile-b", "endpoint-a"));
+        assert!(!metadata.is_compatible("model-a", "profile-a", "endpoint-b"));
     }
 
     // --- Property tests ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -433,7 +433,13 @@ impl Default for PitlaneMcp {
 impl PitlaneMcp {
     pub fn new() -> Self {
         let watcher_registry = Arc::new(WatcherRegistry::new());
-        let embed_config = EmbedConfig::from_env().map(Arc::new);
+        let embed_config = match EmbedConfig::try_from_env() {
+            Ok(config) => config.map(Arc::new),
+            Err(err) => {
+                tracing::error!("invalid embedding configuration: {err}");
+                None
+            }
+        };
         let tool_router = Self::tool_router();
         let public_tool_router = build_public_tool_router(tool_router.clone());
         Self {

--- a/src/tools/get_index_stats.rs
+++ b/src/tools/get_index_stats.rs
@@ -45,7 +45,7 @@ pub async fn get_index_stats(params: GetIndexStatsParams) -> anyhow::Result<Valu
 
     // Embedding progress
     let total_symbols = index.symbol_count();
-    let embed_config = EmbedConfig::from_env();
+    let embed_config = EmbedConfig::try_from_env()?;
     let canonical = resolve_project_path(&params.project)?;
     let profile = load_project_meta(&canonical)
         .ok()

--- a/src/tools/index_project.rs
+++ b/src/tools/index_project.rs
@@ -1125,6 +1125,7 @@ mod tests {
         let embed_config = Some(Arc::new(EmbedConfig {
             url: server.url("/"),
             model: "test".to_string(),
+            headers: reqwest::header::HeaderMap::new(),
         }));
 
         let params = IndexProjectParams {
@@ -1178,6 +1179,7 @@ mod tests {
         let embed_config = Some(Arc::new(EmbedConfig {
             url: server.url("/"),
             model: "test".to_string(),
+            headers: reqwest::header::HeaderMap::new(),
         }));
 
         let params = IndexProjectParams {

--- a/src/tools/investigate.rs
+++ b/src/tools/investigate.rs
@@ -282,7 +282,7 @@ pub async fn investigate(params: InvestigateParams) -> anyhow::Result<Value> {
 
     // Phase 2: Run semantic/bm25 search with each sub-query to fill gaps.
     if discovered_ids.len() < MAX_INLINE_SYMBOLS {
-        let semantic_cfg = EmbedConfig::from_env().map(Arc::new);
+        let semantic_cfg = EmbedConfig::try_from_env()?.map(Arc::new);
         let mode = if semantic_cfg.is_some() {
             "semantic"
         } else {

--- a/src/tools/orchestrator.rs
+++ b/src/tools/orchestrator.rs
@@ -1827,7 +1827,7 @@ async fn locate_symbols(
     limit: usize,
     mode: &str,
 ) -> anyhow::Result<Vec<Value>> {
-    let semantic_cfg = EmbedConfig::from_env().map(Arc::new);
+    let semantic_cfg = EmbedConfig::try_from_env()?.map(Arc::new);
     let query_mode = if mode == "semantic" {
         if semantic_cfg.is_some() {
             "semantic"

--- a/src/tools/search_symbols.rs
+++ b/src/tools/search_symbols.rs
@@ -301,7 +301,11 @@ pub async fn search_symbols(params: SearchSymbolsParams) -> anyhow::Result<Value
             let store_metadata = EmbedStoreMetadata::load(&store_path).ok().flatten();
             if let Some(metadata) = &store_metadata {
                 let expected = document_fingerprint(&embed_cfg.model);
-                if !metadata.is_compatible(&embed_cfg.model, &expected) {
+                if !metadata.is_compatible(
+                    &embed_cfg.model,
+                    &expected,
+                    &crate::embed::endpoint_fingerprint(&embed_cfg.url, &embed_cfg.headers),
+                ) {
                     return Err(anyhow::anyhow!(
                         "Embedding cache was built with a different model, document profile, or query/document prefix. Re-run ensure_project_ready with force=true to rebuild embeddings."
                     ));
@@ -997,6 +1001,7 @@ mod tests {
         let embed_config = Some(Arc::new(EmbedConfig {
             url: "http://localhost:11434/api/embeddings".to_string(),
             model: "nomic-embed-text".to_string(),
+            headers: reqwest::header::HeaderMap::new(),
         }));
 
         let params = SearchSymbolsParams {
@@ -1053,6 +1058,7 @@ mod tests {
             let embed_config_broken = Some(Arc::new(EmbedConfig {
                 url: "http://127.0.0.1:19999/api/embeddings".to_string(),
                 model: "nomic-embed-text".to_string(),
+                headers: reqwest::header::HeaderMap::new(),
             }));
             let params_with_embed = SearchSymbolsParams {
                 project: project.clone(),
@@ -1112,6 +1118,7 @@ mod tests {
         let embed_config = Some(Arc::new(EmbedConfig {
             url: server.url("/"),
             model: "test-model".to_string(),
+            headers: reqwest::header::HeaderMap::new(),
         }));
 
         let params = SearchSymbolsParams {


### PR DESCRIPTION
## Summary

- Support authenticated OpenAI-compatible external embedding endpoints.
- Add arbitrary headers, endpoint-aware cache identity, native system CA roots, and configurable concurrency.
- Retry rate-limited and transient gateway responses with Retry-After and exponential backoff.
- Document configuration and add regression coverage.

## Validation

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- Live gateway test indexed 1,410 symbols with 0 skipped using `BAAI/bge-large-en-v1.5`.
- Live semantic search returned results.