### PR TITLE
fix: invalidate investigate answers when inputs or indexed content change

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -37,6 +37,9 @@ pub fn insert(path: PathBuf, index: SymbolIndex) -> Arc<SymbolIndex> {
 /// reload from disk and repopulate the cache.
 pub fn invalidate(path: &Path) {
     rw_write(&CACHE).remove(path);
+    // The symbol index changed: cached investigate answers for this project
+    // may now reference stale source or outdated symbol sets.
+    crate::session::invalidate_investigate_cache(path);
 }
 
 #[cfg(test)]

--- a/src/session.rs
+++ b/src/session.rs
@@ -23,6 +23,9 @@ struct ProjectSessionState {
     recent_content: HashMap<String, u64>,
     recent_target_content: HashMap<String, (String, u64)>,
     investigate_cache: HashMap<String, (Value, u64)>,
+    /// Bumped whenever indexed content changes so stale investigate answers
+    /// are never served, even if the cache map itself still holds entries.
+    investigate_epoch: u64,
 }
 
 struct SessionEntry {
@@ -357,6 +360,23 @@ fn score_recent(last_seen: Option<u64>, now: u64, base: i32) -> i32 {
     (base - age * 2).max(0)
 }
 
+/// Drop every cached `investigate` answer for this project and bump the
+/// epoch so any key computed before this point can no longer hit.
+///
+/// Called by `crate::cache::invalidate` whenever the symbol index changes
+/// (reindexing via `index_project`, or watcher-driven updates).
+pub fn invalidate_investigate_cache(project: &Path) {
+    with_state_mut(project, |state| {
+        state.investigate_cache.clear();
+        state.investigate_epoch = state.investigate_epoch.wrapping_add(1);
+    });
+}
+
+/// Current investigate-cache epoch for this project. Part of the cache key.
+pub fn investigate_epoch(project: &Path) -> u64 {
+    with_state(project, |state| state.investigate_epoch)
+}
+
 fn prune_investigate_cache(state: &mut ProjectSessionState) {
     if state.investigate_cache.len() <= MAX_INVESTIGATE_CACHE {
         return;
@@ -545,5 +565,19 @@ mod tests {
         let cached = get_investigate_cache(&project, key).expect("cached payload");
         assert_eq!(cached["answer"], payload["answer"]);
         assert_eq!(cached["symbols_read"], payload["symbols_read"]);
+    }
+
+    #[test]
+    fn test_invalidate_investigate_cache_drops_entries_and_bumps_epoch() {
+        let project = unique_project("session-test-invalidate");
+        let key = "investigate:v2:0;gitignore";
+        store_investigate_cache(&project, key, serde_json::json!({"answer": "old"}));
+        assert!(get_investigate_cache(&project, key).is_some());
+
+        let epoch_before = investigate_epoch(&project);
+        invalidate_investigate_cache(&project);
+
+        assert!(get_investigate_cache(&project, key).is_none());
+        assert_ne!(investigate_epoch(&project), epoch_before);
     }
 }

--- a/src/tools/index_project.rs
+++ b/src/tools/index_project.rs
@@ -308,7 +308,10 @@ async fn do_index_project(
         tracing::warn!(error = %e, "BM25 index build failed; search will fall back to exact");
     }
 
-    let cached_index = crate::cache::insert(canonical_for_meta, index);
+    let cached_index = crate::cache::insert(canonical_for_meta.clone(), index);
+    // The indexed content may have changed: stale cached investigate answers
+    // must not be served for the fresh index.
+    crate::session::invalidate_investigate_cache(&canonical_for_meta);
 
     // Embedding phase (opt-in) — runs in a detached background task so the
     // MCP response returns as soon as the symbol index is ready. Semantic

--- a/src/tools/investigate.rs
+++ b/src/tools/investigate.rs
@@ -219,8 +219,34 @@ fn normalize_investigate_key(query: &str) -> String {
     }
 }
 
-fn investigate_cache_key(query: &str) -> String {
-    format!("investigate:{}", normalize_investigate_key(query))
+fn investigate_cache_key(
+    query: &str,
+    language: Option<&str>,
+    scope: Option<&str>,
+    epoch: u64,
+) -> String {
+    // Language and scope filters change which symbols an investigation may
+    // consider, so they must be part of the key. The epoch changes whenever
+    // the index is rebuilt (reindex or watcher update), invalidating answers
+    // that may reference stale source.
+    let mut key = format!("investigate:v2:{}", epoch);
+    if let Some(lang) = language {
+        let lang = lang.trim().to_lowercase();
+        if !lang.is_empty() {
+            key.push_str(";lang=");
+            key.push_str(&lang);
+        }
+    }
+    if let Some(scope) = scope {
+        let scope = scope.trim();
+        if !scope.is_empty() {
+            key.push_str(";scope=");
+            key.push_str(scope);
+        }
+    }
+    key.push(';');
+    key.push_str(&normalize_investigate_key(query));
+    key
 }
 
 fn mark_investigate_repeated(mut response: Value) -> Value {
@@ -244,7 +270,12 @@ pub async fn investigate(params: InvestigateParams) -> anyhow::Result<Value> {
         return Err(anyhow::anyhow!("query must not be empty"));
     }
 
-    let cache_key = investigate_cache_key(&query);
+    let cache_key = investigate_cache_key(
+        &query,
+        params.language.as_deref(),
+        params.scope.as_deref(),
+        session::investigate_epoch(&canonical),
+    );
     if let Some(cached) = session::get_investigate_cache(&canonical, &cache_key) {
         return Ok(mark_investigate_repeated(cached));
     }
@@ -634,6 +665,118 @@ mod tests {
         assert_eq!(second["answer"], first["answer"]);
         assert_eq!(second["symbols_read"], first["symbols_read"]);
         assert!(second["guidance"].as_str().is_some());
+    }
+
+    #[test]
+    fn test_investigate_cache_key_separates_filters_and_epochs() {
+        let base = investigate_cache_key("gitignore", None, None, 0);
+        assert!(base.contains("gitignore"));
+        // Language filter changes the key.
+        assert_ne!(
+            investigate_cache_key("gitignore", Some("rust"), None, 0),
+            base
+        );
+        // Scope filter changes the key.
+        assert_ne!(
+            investigate_cache_key("gitignore", None, Some("src/tools"), 0),
+            base
+        );
+        // A new epoch (index rebuild) changes the key.
+        assert_ne!(investigate_cache_key("gitignore", None, None, 1), base);
+        // Filters are normalized so casing/whitespace alone cannot bypass the cache.
+        assert_eq!(
+            investigate_cache_key("gitignore", Some(" Rust "), None, 0),
+            investigate_cache_key("gitignore", Some("rust"), None, 0)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_investigate_cache_distinguishes_language_filter() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("lib.rs"), "pub fn alpha() {}\n").unwrap();
+        std::fs::write(dir.path().join("mod.py"), "def alpha():\n    pass\n").unwrap();
+        let project = setup_project(&dir).await;
+
+        let unfiltered = investigate(InvestigateParams {
+            project: project.clone(),
+            query: "alpha".to_string(),
+            language: None,
+            scope: None,
+        })
+        .await
+        .unwrap();
+        assert_eq!(unfiltered["repeated"], json!(false));
+
+        // Same query but scoped to Python must not reuse the unfiltered answer.
+        let py = investigate(InvestigateParams {
+            project: project.clone(),
+            query: "alpha".to_string(),
+            language: Some("python".to_string()),
+            scope: None,
+        })
+        .await
+        .unwrap();
+        assert_eq!(py["repeated"], json!(false));
+
+        // And the exact same filter still hits the cache.
+        let py_repeat = investigate(InvestigateParams {
+            project,
+            query: "alpha".to_string(),
+            language: Some("python".to_string()),
+            scope: None,
+        })
+        .await
+        .unwrap();
+        assert_eq!(py_repeat["repeated"], json!(true));
+        assert_eq!(py_repeat["answer"], py["answer"]);
+    }
+
+    #[tokio::test]
+    async fn test_investigate_cache_invalidated_by_reindex_after_content_change() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("lib.rs"), "pub fn stale_symbol() {}\n").unwrap();
+        let project = setup_project(&dir).await;
+
+        let first = investigate(InvestigateParams {
+            project: project.clone(),
+            query: "stale_symbol".to_string(),
+            language: None,
+            scope: None,
+        })
+        .await
+        .unwrap();
+        assert_eq!(first["repeated"], json!(false));
+
+        // Repeating before any change is a cache hit.
+        let repeat = investigate(InvestigateParams {
+            project: project.clone(),
+            query: "stale_symbol".to_string(),
+            language: None,
+            scope: None,
+        })
+        .await
+        .unwrap();
+        assert_eq!(repeat["repeated"], json!(true));
+
+        // Edit the source and reindex; the cached answer is now stale and
+        // must not be returned.
+        std::fs::write(
+            dir.path().join("lib.rs"),
+            "pub fn fresh_symbol() {}\npub fn unrelated() {}\n",
+        )
+        .unwrap();
+        setup_project(&dir).await;
+
+        let after = investigate(InvestigateParams {
+            project,
+            query: "stale_symbol".to_string(),
+            language: None,
+            scope: None,
+        })
+        .await
+        .unwrap();
+        assert_eq!(after["repeated"], json!(false));
+        assert!(after["answer"].as_str().unwrap().contains("fresh_symbol"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem
`investigate` could return a cached answer for the wrong language or scope (e.g. a Rust-only request served a cached Python answer), or stale source after a reindex. The cache key was built only from normalized query words.

## Changes
- **Cache key** (`src/tools/investigate.rs`): now includes the language filter, scope filter (both normalized), and a per-project cache epoch.
- **Invalidation** (`src/session.rs`, `src/cache.rs`, `src/tools/index_project.rs`): a per-project epoch is bumped and cached answers cleared whenever the symbol index changes — via `cache::invalidate` (covers reindexing and watcher-driven updates) and the `index_project` insert path (which bypassed `invalidate`).
- **Regression tests**: changed language filter no longer hits cache (and same filter still does); reindexing edited content invalidates the cached answer; key-separation unit test for filters and epochs.

Fixes #73