### PR TITLE
perf: avoid rebuilding the entire navigation graph for every changed file

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use tree_sitter::{Node, Parser};
 
 use crate::index::SymbolIndex;
-use crate::indexer::language::{Language, Symbol, SymbolKind};
+use crate::indexer::language::{Language, Symbol, SymbolId, SymbolKind};
 use crate::path_policy::open_regular_file;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -93,18 +93,55 @@ pub fn read_symbol_source(sym: &Symbol, include_context: bool) -> anyhow::Result
     }
 }
 
+/// Name-to-candidate lookup built once per graph build. Replaces scanning
+/// every indexed symbol for each source symbol (O(N²)) with O(1) lookups.
+pub(crate) struct CandidateIndex {
+    by_name: HashMap<(Language, String), Vec<SymbolId>>,
+}
+
+impl CandidateIndex {
+    pub fn build(index: &SymbolIndex) -> Self {
+        let mut by_name: HashMap<(Language, String), Vec<SymbolId>> = HashMap::new();
+        for sym in index.symbols.values() {
+            by_name
+                .entry((sym.language.clone(), sym.name.clone()))
+                .or_default()
+                .push(sym.id.clone());
+        }
+        Self { by_name }
+    }
+
+    /// Same-language candidates for `name`, excluding `excluding_id`.
+    fn lookup<'a>(
+        &self,
+        index: &'a SymbolIndex,
+        language: Language,
+        name: &str,
+        excluding_id: &str,
+    ) -> Vec<&'a Symbol> {
+        self.by_name
+            .get(&(language, name.to_string()))
+            .into_iter()
+            .flatten()
+            .filter(|id| id.as_str() != excluding_id)
+            .filter_map(|id| index.symbols.get(id))
+            .collect()
+    }
+}
+
 pub fn build_navigation_graph(index: &SymbolIndex) -> NavigationGraph {
     let mut graph = NavigationGraph {
         built: true,
         ..Default::default()
     };
 
+    let candidates = CandidateIndex::build(index);
     for sym in index.symbols.values() {
         let source_text = match read_symbol_source(sym, false) {
             Ok(source) => source,
             Err(_) => continue,
         };
-        for reference in scan_direct_references(index, sym, &source_text) {
+        for reference in scan_direct_references(index, sym, &source_text, &candidates) {
             let Some(target) = index.symbols.get(&reference.id) else {
                 continue;
             };
@@ -163,7 +200,7 @@ pub fn collect_direct_references(
             &owned_source
         }
     };
-    scan_direct_references(index, sym, source_text)
+    scan_direct_references(index, sym, source_text, &CandidateIndex::build(index))
 }
 
 pub fn collect_direct_callable_references(
@@ -246,10 +283,11 @@ fn scan_direct_references(
     index: &SymbolIndex,
     sym: &Symbol,
     source_text: &str,
+    candidates: &CandidateIndex,
 ) -> Vec<DirectReference> {
     let mut refs = Vec::new();
     let cap_generic_confidence = if sym.language == Language::Rust {
-        match scan_rust_direct_references(index, sym, source_text) {
+        match scan_rust_direct_references(index, sym, source_text, candidates) {
             Some(mut rust_refs) => {
                 refs.append(&mut rust_refs);
                 Some(0.84)
@@ -265,6 +303,7 @@ fn scan_direct_references(
         sym,
         source_text,
         cap_generic_confidence,
+        candidates,
     ));
     sort_direct_references(&mut refs);
     refs
@@ -391,37 +430,26 @@ fn scan_generic_direct_references(
     sym: &Symbol,
     source_text: &str,
     max_confidence: Option<f32>,
+    candidates: &CandidateIndex,
 ) -> Vec<DirectReference> {
     // Comments and strings must not contribute call evidence: strip them
     // before extracting identifiers or searching for evidence lines.
     let cleaned = strip_comments_and_strings(source_text);
     let identifiers = extract_identifiers(&cleaned);
 
-    // A name that resolves to multiple same-language candidates is ambiguous:
-    // a name match cannot distinguish which one (if any) is actually called.
-    let mut name_counts: HashMap<&str, usize> = HashMap::new();
-    for candidate in index
-        .symbols
-        .values()
-        .filter(|candidate| candidate.language == sym.language)
-    {
-        *name_counts.entry(candidate.name.as_str()).or_default() += 1;
-    }
-
-    index
-        .symbols
-        .values()
+    identifiers
+        .into_iter()
         // Candidate resolution is restricted to the referencing symbol's
         // language: a name match in another language is not a call.
-        .filter(|candidate| {
-            candidate.language == sym.language
-                && candidate.id != sym.id
-                && identifiers.contains(candidate.name.as_str())
-        })
+        .flat_map(|name| candidates.lookup(index, sym.language.clone(), name, &sym.id))
         .map(|candidate| {
-            let ambiguous = name_counts
-                .get(candidate.name.as_str())
-                .is_some_and(|count| *count > 1);
+            // A name that resolves to multiple same-language candidates is
+            // ambiguous: a name match cannot distinguish which one (if any)
+            // is actually called.
+            let ambiguous = candidates
+                .lookup(index, sym.language.clone(), &candidate.name, &sym.id)
+                .len()
+                > 1;
             let (evidence, mut confidence) = reference_evidence(
                 source_text,
                 &cleaned,
@@ -622,51 +650,32 @@ fn scan_rust_direct_references(
     index: &SymbolIndex,
     sym: &Symbol,
     source_text: &str,
+    candidates: &CandidateIndex,
 ) -> Option<Vec<DirectReference>> {
     let matches = collect_rust_call_matches(source_text)?;
 
-    // Resolve call targets within the same language only, and treat a name
-    // shared by multiple Rust candidates as ambiguous.
-    let mut name_counts: HashMap<&str, usize> = HashMap::new();
-    for candidate in index
-        .symbols
-        .values()
-        .filter(|candidate| candidate.language == Language::Rust)
-    {
-        *name_counts.entry(candidate.name.as_str()).or_default() += 1;
-    }
-
     let mut refs = Vec::new();
     for matched in matches {
-        let ambiguous = name_counts
-            .get(matched.name.as_str())
-            .is_some_and(|count| *count > 1);
-        refs.extend(
-            index
-                .symbols
-                .values()
-                .filter(|candidate| {
-                    candidate.language == Language::Rust
-                        && candidate.id != sym.id
-                        && candidate.name == matched.name
-                })
-                .map(|candidate| {
-                    let confidence = if ambiguous {
-                        matched.confidence.min(AMBIGUOUS_CONFIDENCE_CAP)
-                    } else {
-                        matched.confidence
-                    };
-                    DirectReference {
-                        id: candidate.id.clone(),
-                        name: candidate.name.clone(),
-                        kind: candidate.kind.to_string(),
-                        file: candidate.file.to_string_lossy().replace('\\', "/"),
-                        line_start: candidate.line_start,
-                        evidence: matched.evidence.clone(),
-                        confidence,
-                    }
-                }),
-        );
+        // Resolve call targets within the same language only, and treat a
+        // name shared by multiple Rust candidates as ambiguous.
+        let resolved = candidates.lookup(index, Language::Rust, &matched.name, &sym.id);
+        let ambiguous = resolved.len() > 1;
+        refs.extend(resolved.into_iter().map(|candidate| {
+            let confidence = if ambiguous {
+                matched.confidence.min(AMBIGUOUS_CONFIDENCE_CAP)
+            } else {
+                matched.confidence
+            };
+            DirectReference {
+                id: candidate.id.clone(),
+                name: candidate.name.clone(),
+                kind: candidate.kind.to_string(),
+                file: candidate.file.to_string_lossy().replace('\\', "/"),
+                line_start: candidate.line_start,
+                evidence: matched.evidence.clone(),
+                confidence,
+            }
+        }));
     }
     sort_direct_references(&mut refs);
     Some(refs)

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -231,7 +231,11 @@ impl Indexer {
         Ok((index, file_count))
     }
 
-    /// Re-index a single file
+    /// Re-index a single file.
+    ///
+    /// Note: this invalidates the navigation graph (`remove_file` resets it)
+    /// but does NOT rebuild it. Use [`Self::reindex_files`] for batched
+    /// updates, which rebuilds the graph exactly once after all files.
     pub fn reindex_file(
         &self,
         file_path: &Path,
@@ -254,9 +258,26 @@ impl Indexer {
                 index.insert(symbol);
             }
         }
-        index.rebuild_navigation_graph();
 
         Ok(())
+    }
+
+    /// Re-index a batch of files and rebuild the navigation graph exactly
+    /// once. Rebuilding per file made watcher updates quadratic: each
+    /// `reindex_file` discarded the graph and the rebuild rescanned every
+    /// symbol's source from disk.
+    pub fn reindex_files(
+        &self,
+        paths: &HashSet<std::path::PathBuf>,
+        root: &Path,
+        index: &mut SymbolIndex,
+    ) {
+        for path in paths {
+            if let Err(e) = self.reindex_file(path, root, index) {
+                tracing::warn!(file = %path.display(), error = %e, "reindex_file failed");
+            }
+        }
+        index.rebuild_navigation_graph();
     }
 
     fn parse_file(&self, path: &Path, root: &Path) -> anyhow::Result<Vec<language::Symbol>> {
@@ -1131,6 +1152,83 @@ mod tests {
 
         // Previous symbols removed, oversized file produces no new symbols
         assert_eq!(index.symbol_count(), 0);
+    }
+
+    #[test]
+    fn test_reindex_files_rebuilds_graph_once_and_keeps_edges_correct() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("lib.rs"),
+            b"fn callee() {}\nfn root() { callee(); }\n",
+        )
+        .unwrap();
+        let other = dir.path().join("other.rs");
+        std::fs::write(&other, b"fn other_root() { callee(); }\n").unwrap();
+
+        let indexer = create_indexer();
+        let (mut index, _) = indexer.index_project(dir.path(), &[]).unwrap();
+        assert!(index.graph.built);
+        assert_eq!(index.symbol_count(), 3);
+
+        // Edit both files: callee renames, both callers change.
+        std::fs::write(
+            dir.path().join("lib.rs"),
+            b"fn renamed_callee() {}\nfn root() { renamed_callee(); }\n",
+        )
+        .unwrap();
+        std::fs::write(&other, b"fn other_root() { renamed_callee(); }\n").unwrap();
+
+        let changed: HashSet<std::path::PathBuf> =
+            [dir.path().join("lib.rs"), other.clone()].into();
+        indexer.reindex_files(&changed, dir.path(), &mut index);
+
+        // Graph is rebuilt and consistent with the new content.
+        assert!(index.graph.built);
+        assert_eq!(index.symbol_count(), 3);
+        let names: Vec<_> = index.symbols.values().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"renamed_callee"));
+        assert!(!names.contains(&"callee"));
+
+        // Edges point at the renamed symbol, not a stale one.
+        let callee_id = index
+            .symbols
+            .values()
+            .find(|s| s.name == "renamed_callee")
+            .unwrap()
+            .id
+            .clone();
+        let incoming_count = index
+            .graph
+            .incoming
+            .get(&callee_id)
+            .map(|edges| edges.len())
+            .unwrap_or(0);
+        assert_eq!(
+            incoming_count, 2,
+            "both callers must reference the renamed symbol"
+        );
+    }
+
+    #[test]
+    fn test_reindex_file_leaves_graph_unbuilt_until_explicit_rebuild() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("lib.rs");
+        std::fs::write(&file_path, b"fn alpha() {}\n").unwrap();
+
+        let indexer = create_indexer();
+        let (mut index, _) = indexer.index_project(dir.path(), &[]).unwrap();
+        assert!(index.graph.built);
+
+        std::fs::write(&file_path, b"fn beta() {}\n").unwrap();
+        indexer
+            .reindex_file(&file_path, dir.path(), &mut index)
+            .unwrap();
+
+        // reindex_file invalidates but does not rebuild the graph; callers
+        // doing single-file updates must call rebuild_navigation_graph().
+        assert!(!index.graph.built);
+        index.rebuild_navigation_graph();
+        assert!(index.graph.built);
     }
 
     #[cfg(unix)]

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -267,16 +267,13 @@ async fn reindex_batch(
     let removed_ids: Vec<crate::indexer::language::SymbolId>;
     {
         let mut idx = index.write().await;
-        // Capture symbol IDs for changed files BEFORE reindex_file mutates by_file
+        // Capture symbol IDs for changed files BEFORE reindex mutates by_file
         removed_ids = paths
             .iter()
             .flat_map(|p| idx.by_file.get(p).cloned().unwrap_or_default())
             .collect();
-        for path in paths {
-            if let Err(e) = indexer.reindex_file(path, root, &mut idx) {
-                eprintln!("Error re-indexing {:?}: {}", path, e);
-            }
-        }
+        // One graph rebuild for the whole batch, not one per changed file.
+        indexer.reindex_files(paths, root, &mut idx);
 
         // Flush updated index to disk while holding the write lock for consistency.
         if let Err(e) = save_index(&idx, index_path) {


### PR DESCRIPTION
## Problem
- **Per-file rebuilds**: the watcher's `reindex_batch` looped `reindex_file` over the changed paths, and each call discarded the navigation graph (`remove_file` resets it) and rebuilt the whole thing — one full rebuild per changed file in a burst.
- **Quadratic candidate lookup**: graph construction scanned every indexed symbol for each source symbol's references (O(N²)).

## Changes
- **`src/indexer/mod.rs`**: new `reindex_files(paths, root, index)` that reindexes the batch and rebuilds the navigation graph exactly once. `reindex_file` no longer rebuilds (documented on the method); single-file callers must call `rebuild_navigation_graph()` explicitly.
- **`src/watcher.rs`**: `reindex_batch` uses the batched path.
- **`src/graph.rs`**: new `CandidateIndex` — a `(language, name) → [symbol]` map built once per graph build. Both the generic scan and the Rust AST-based scan do O(1) candidate lookups instead of scanning `index.symbols` per source symbol; ambiguity detection now reads the candidate count directly.

## Tests
- Batched reindex of two edited files: graph stays built, renamed symbols resolve, incoming edges count correct.
- Single-file `reindex_file` leaves graph unbuilt until explicit rebuild (guards the new contract).

## Notes on benchmarks
The issue also asks for Guava-corpus benchmarks (single-file edits, edit bursts, initial indexing). Those extended runs did not finish in review per the issue text; this PR lands the structural fixes (one rebuild per batch, O(1) lookups). Benchmark harness is left for a follow-up so it can run outside CI time limits.

Full suite: 616 passed; clippy and rustfmt clean.

Fixes #79