### PR TITLE
fix: apply the same exclusion policy to watcher updates and initial indexing

### DIFF
--- a/src/index/format.rs
+++ b/src/index/format.rs
@@ -32,6 +32,12 @@ pub struct IndexMeta {
     pub dir_mtimes: HashMap<String, u64>,
     #[serde(default)]
     pub source_file_count: usize,
+    /// Effective exclusion patterns used at indexing time (custom patterns,
+    /// defaults, and `.gitignore` entries). The watcher reuses these so
+    /// incremental updates and full resyncs apply the same policy as the
+    /// initial indexing.
+    #[serde(default)]
+    pub effective_excludes: Vec<String>,
     pub repo_profile: RepoProfile,
 }
 
@@ -44,6 +50,7 @@ impl IndexMeta {
             file_mtimes: HashMap::new(),
             dir_mtimes: HashMap::new(),
             source_file_count: 0,
+            effective_excludes: Vec::new(),
             repo_profile: RepoProfile::default(),
         }
     }

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -54,7 +54,7 @@ impl Indexer {
         Self { parsers, ext_map }
     }
 
-    fn build_exclude_set(patterns: &[String]) -> anyhow::Result<GlobSet> {
+    pub fn build_exclude_set(patterns: &[String]) -> anyhow::Result<GlobSet> {
         let mut builder = GlobSetBuilder::new();
         for pat in patterns {
             builder.add(Glob::new(pat)?);
@@ -578,6 +578,35 @@ pub fn is_excluded_dir_name_with_custom(name: &str, extra_excluded_dirs: &HashSe
 pub fn is_excluded_dir_name(name: &str) -> bool {
     let extra_excluded_dirs = extra_excluded_dir_names();
     is_excluded_dir_name_with_custom(name, &extra_excluded_dirs)
+}
+
+/// Mirrors the walk filter of `index_project_with_progress`: a path is
+/// excluded when an exclude glob matches its project-relative path, or any
+/// path component is an excluded directory name (built-in or custom).
+///
+/// The watcher uses this so incremental updates apply the same exclusion
+/// policy as initial indexing.
+pub fn path_is_excluded(
+    path: &Path,
+    root: &Path,
+    exclude_set: &GlobSet,
+    extra_excluded_dirs: &HashSet<String>,
+) -> bool {
+    let Ok(rel) = path.strip_prefix(root) else {
+        return false;
+    };
+    if rel == Path::new("") {
+        return true;
+    }
+    let rel_str = rel.to_string_lossy();
+    if exclude_set.is_match(rel_str.as_ref()) {
+        return true;
+    }
+    rel.components().any(|c| {
+        c.as_os_str()
+            .to_str()
+            .is_some_and(|name| is_excluded_dir_name_with_custom(name, extra_excluded_dirs))
+    })
 }
 
 #[cfg(test)]

--- a/src/tools/index_project.rs
+++ b/src/tools/index_project.rs
@@ -71,8 +71,25 @@ pub async fn index_project(mut params: IndexProjectParams) -> anyhow::Result<Val
     let index_path = idx_dir.join("index.bin");
     let meta_path = idx_dir.join("meta.json");
 
+    // The cached path is only valid when the persisted effective exclusions
+    // still match what this invocation would compute; otherwise a changed
+    // exclude set would silently keep serving symbols that are now excluded.
+    let cached_excludes_match = !force
+        && index_path.exists()
+        && meta_path.exists()
+        && load_meta(&meta_path)
+            .map(|m| m.effective_excludes)
+            .map(|persisted| {
+                let mut a = persisted.clone();
+                a.sort();
+                let mut b = exclude.clone();
+                b.sort();
+                a == b
+            })
+            .unwrap_or(false);
+
     // Check if we can use the up-to-date on-disk index.
-    if !force && index_path.exists() && meta_path.exists() {
+    if cached_excludes_match && meta_path.exists() {
         if let Ok(meta) = load_meta(&meta_path) {
             if is_index_up_to_date(&canonical, &meta, &exclude) {
                 if let Ok(index) = crate::index::format::load_index(&index_path) {
@@ -298,6 +315,9 @@ async fn do_index_project(
     meta.file_mtimes = snapshot.file_mtimes;
     meta.dir_mtimes = snapshot.dir_mtimes;
     meta.source_file_count = file_count;
+    // Persist the effective exclusions so watcher updates and full resyncs
+    // apply the same policy (issue #74).
+    meta.effective_excludes = exclude.clone();
     save_meta(&meta, &meta_path)?;
 
     // Build the BM25 index. Invalidate any stale cached reader first so the
@@ -971,6 +991,65 @@ mod tests {
             "adding a new supported file must invalidate the cached index"
         );
         assert_eq!(refreshed["file_count"], json!(2));
+    }
+
+    fn clone_params(p: &IndexProjectParams) -> IndexProjectParams {
+        IndexProjectParams {
+            path: p.path.clone(),
+            exclude: p.exclude.clone(),
+            force: p.force,
+            max_files: p.max_files,
+            progress_token: p.progress_token.clone(),
+            peer: p.peer.clone(),
+            embed_config: p.embed_config.clone(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_index_project_cached_path_invalidated_by_changed_excludes() {
+        // Issue #74: a changed exclude set must not be served from the cache,
+        // otherwise symbols that are now excluded would remain visible.
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join("vendor")).unwrap();
+        std::fs::write(dir.path().join("lib.rs"), b"pub fn foo() {}").unwrap();
+        std::fs::write(dir.path().join("vendor/dep.rs"), b"pub fn dep_fn() {}").unwrap();
+
+        let base = IndexProjectParams {
+            path: dir.path().to_string_lossy().to_string(),
+            exclude: None,
+            force: Some(true),
+            max_files: None,
+            progress_token: None,
+            peer: None,
+            embed_config: None,
+        };
+        let initial = index_project(clone_params(&base)).await.unwrap();
+        assert_eq!(initial["file_count"], json!(2));
+
+        // Same content, but a different effective exclusion set.
+        let narrowed = IndexProjectParams {
+            exclude: Some(vec!["vendor/**".to_string()]),
+            force: Some(false),
+            max_files: None,
+            progress_token: None,
+            peer: None,
+            embed_config: None,
+            path: base.path.clone(),
+        };
+        let resp = index_project(narrowed).await.unwrap();
+        assert_eq!(
+            resp["status"],
+            json!("indexed"),
+            "changed excludes must invalidate the cached path, resp={resp}"
+        );
+        assert_eq!(resp["file_count"], json!(1));
+
+        // And restoring the unchanged excludes re-indexes (the narrowed run
+        // stopped tracking vendor/dep.rs's mtime, so it correctly counts as
+        // new again).
+        let restored = index_project(clone_params(&base)).await.unwrap();
+        assert_eq!(restored["status"], json!("indexed"));
+        assert_eq!(restored["file_count"], json!(2));
     }
 
     #[tokio::test]

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -11,11 +11,27 @@ use crate::embed::EmbedConfig;
 use crate::index::format::{index_dir, load_meta, save_index, save_meta, IndexMeta};
 use crate::index::SymbolIndex;
 use crate::indexer::is_supported_extension;
-use crate::indexer::{registry, Indexer};
+use crate::indexer::{
+    default_exclude_patterns, load_gitignore_patterns, path_is_excluded, registry, Indexer,
+};
 use crate::tools::index_project::current_source_snapshot;
 
 const DEBOUNCE_WINDOW: Duration = Duration::from_millis(500);
 const CHANNEL_CAPACITY: usize = 1024;
+
+/// Effective exclusion patterns for the project: the patterns persisted by
+/// the last indexing run, falling back to defaults plus `.gitignore` for
+/// indexes created before exclusions were persisted.
+fn effective_exclude_patterns(root: &Path, meta_path: &Path) -> Vec<String> {
+    if let Ok(meta) = load_meta(meta_path) {
+        if !meta.effective_excludes.is_empty() {
+            return meta.effective_excludes;
+        }
+    }
+    let mut patterns = default_exclude_patterns();
+    patterns.extend(load_gitignore_patterns(root));
+    patterns
+}
 
 pub struct ProjectWatcher {
     _watcher: RecommendedWatcher,
@@ -157,7 +173,16 @@ async fn flush_pending(
     overflowed: &Arc<AtomicBool>,
 ) {
     if overflowed.swap(false, Ordering::AcqRel) {
-        full_resync(root, indexer, index, index_path, meta_path, embed_config).await;
+        full_resync(
+            root,
+            indexer,
+            index,
+            index_path,
+            meta_path,
+            embed_config,
+            effective_exclude_patterns(root, meta_path),
+        )
+        .await;
         pending.clear();
         return;
     }
@@ -186,6 +211,7 @@ async fn full_resync(
     index_path: &Path,
     meta_path: &Path,
     embed_config: Option<Arc<EmbedConfig>>,
+    exclude_patterns: Vec<String>,
 ) {
     let old_removed_ids = {
         let idx = index.read().await;
@@ -194,7 +220,11 @@ async fn full_resync(
 
     let root_buf = root.to_path_buf();
     let indexer = Arc::clone(indexer);
-    let rebuilt = tokio::task::spawn_blocking(move || indexer.index_project(&root_buf, &[])).await;
+    // Reuse the effective exclusions from initial indexing (issue #74): an
+    // empty pattern list would silently re-index excluded directories.
+    let rebuilt =
+        tokio::task::spawn_blocking(move || indexer.index_project(&root_buf, &exclude_patterns))
+            .await;
 
     let (rebuilt_index, source_file_count) = match rebuilt {
         Ok(Ok(result)) => result,
@@ -272,8 +302,28 @@ async fn reindex_batch(
             .iter()
             .flat_map(|p| idx.by_file.get(p).cloned().unwrap_or_default())
             .collect();
+
+        // Apply the same exclusion policy as initial indexing (issue #74):
+        // edits or new files inside excluded directories must not re-enter
+        // the index, and previously indexed files that are now excluded are
+        // dropped.
+        let exclude_patterns = effective_exclude_patterns(root, meta_path);
+        let exclude_set = Indexer::build_exclude_set(&exclude_patterns).unwrap_or_else(|_| {
+            tracing::warn!("watcher: invalid persisted exclude patterns; applying none");
+            globset::GlobSetBuilder::new().build().unwrap()
+        });
+        let extra_excluded_dirs = crate::indexer::extra_excluded_dir_names();
+        let mut accepted: HashSet<PathBuf> = HashSet::new();
+        for path in paths {
+            if path_is_excluded(path, root, &exclude_set, &extra_excluded_dirs) {
+                idx.remove_file(path);
+                continue;
+            }
+            accepted.insert(path.clone());
+        }
+
         // One graph rebuild for the whole batch, not one per changed file.
-        indexer.reindex_files(paths, root, &mut idx);
+        indexer.reindex_files(&accepted, root, &mut idx);
 
         // Flush updated index to disk while holding the write lock for consistency.
         if let Err(e) = save_index(&idx, index_path) {
@@ -619,5 +669,152 @@ mod tests {
         assert!(names.contains(&"a_new"));
         assert!(names.contains(&"b_new"));
         assert!(!names.contains(&"a_old"));
+    }
+
+    // ── Issue #74: watcher applies the same exclusion policy as initial indexing ──
+
+    fn write_meta_with_excludes(dir: &TempDir, excludes: &[&str]) {
+        let mut meta = IndexMeta::new(dir.path());
+        meta.effective_excludes = excludes.iter().map(|s| s.to_string()).collect();
+        save_meta(&meta, &dir.path().join("meta.json")).unwrap();
+    }
+
+    async fn symbol_names(index: &Arc<RwLock<SymbolIndex>>) -> Vec<String> {
+        index
+            .read()
+            .await
+            .symbols
+            .values()
+            .map(|s| s.name.clone())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_watcher_ignores_edits_inside_excluded_directory() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join("ignored")).unwrap();
+        std::fs::write(dir.path().join("lib.rs"), b"fn kept() {}").unwrap();
+        std::fs::write(dir.path().join("ignored/secret.rs"), b"fn secret_old() {}").unwrap();
+
+        let indexer = Arc::new(Indexer::new(registry::build_default_registry()));
+        let (idx, _) = indexer
+            .index_project(dir.path(), &["ignored/**".to_string()])
+            .unwrap();
+        assert!(!idx.symbols.values().any(|s| s.name == "secret_old"));
+        let index = Arc::new(RwLock::new(idx));
+        write_meta_with_excludes(&dir, &["ignored/**"]);
+
+        let (tx, rx) = mpsc::channel(16);
+        let handle = spawn_loop(rx, &dir, indexer, index.clone());
+
+        // Edit inside the excluded directory: must not re-enter the index.
+        std::fs::write(dir.path().join("ignored/secret.rs"), b"fn secret_new() {}").unwrap();
+        // New file inside the excluded directory: must be ignored too.
+        let added = dir.path().join("ignored/added.rs");
+        std::fs::write(&added, b"fn added_fn() {}").unwrap();
+        tx.send(dir.path().join("ignored/secret.rs")).await.unwrap();
+        tx.send(added).await.unwrap();
+        drop(tx);
+        handle.await.unwrap();
+
+        let names = symbol_names(&index).await;
+        assert!(names.iter().any(|n| n == "kept"));
+        assert!(!names.iter().any(|n| n == "secret_new"), "names={names:?}");
+        assert!(!names.iter().any(|n| n == "added_fn"), "names={names:?}");
+    }
+
+    #[tokio::test]
+    async fn test_watcher_drops_previously_indexed_file_now_excluded() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("legacy.rs");
+        std::fs::write(&file, b"fn legacy_old() {}").unwrap();
+
+        // Indexed WITHOUT exclusions, so the symbol is in the index...
+        let (index, indexer) = setup(&dir);
+        assert!(symbol_names(&index).await.iter().any(|n| n == "legacy_old"));
+
+        // ...but the effective policy now excludes it.
+        write_meta_with_excludes(&dir, &["legacy.rs"]);
+
+        let (tx, rx) = mpsc::channel(16);
+        let handle = spawn_loop(rx, &dir, indexer, index.clone());
+
+        std::fs::write(&file, b"fn legacy_new() {}").unwrap();
+        tx.send(file).await.unwrap();
+        drop(tx);
+        handle.await.unwrap();
+
+        let names = symbol_names(&index).await;
+        assert!(!names.iter().any(|n| n == "legacy_old"), "names={names:?}");
+        assert!(!names.iter().any(|n| n == "legacy_new"), "names={names:?}");
+    }
+
+    #[tokio::test]
+    async fn test_full_resync_respects_persisted_excludes() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join("ignored")).unwrap();
+        std::fs::write(dir.path().join("lib.rs"), b"fn kept() {}").unwrap();
+        std::fs::write(dir.path().join("ignored/secret.rs"), b"fn secret_fn() {}").unwrap();
+
+        let indexer = Arc::new(Indexer::new(registry::build_default_registry()));
+        let (idx, _) = indexer
+            .index_project(dir.path(), &["ignored/**".to_string()])
+            .unwrap();
+        let index = Arc::new(RwLock::new(idx));
+        write_meta_with_excludes(&dir, &["ignored/**"]);
+
+        let (tx, rx) = mpsc::channel(16);
+        let handle = spawn_loop_with_overflow(
+            rx,
+            &dir,
+            indexer,
+            index.clone(),
+            Arc::new(AtomicBool::new(true)), // force full resync
+        );
+
+        std::fs::write(dir.path().join("ignored/secret.rs"), b"fn secret_fn2() {}").unwrap();
+        tx.send(dir.path().join("ignored/secret.rs")).await.unwrap();
+        drop(tx);
+        handle.await.unwrap();
+
+        let names = symbol_names(&index).await;
+        assert!(names.iter().any(|n| n == "kept"), "names={names:?}");
+        assert!(!names.iter().any(|n| n == "secret_fn"), "names={names:?}");
+        assert!(!names.iter().any(|n| n == "secret_fn2"), "names={names:?}");
+    }
+
+    #[tokio::test]
+    async fn test_watcher_falls_back_to_defaults_without_persisted_excludes() {
+        // node_modules is a built-in excluded directory name: a file edited
+        // there must be ignored even when no meta excludes were persisted.
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join("node_modules/pkg")).unwrap();
+        std::fs::write(dir.path().join("lib.rs"), b"fn kept() {}").unwrap();
+        std::fs::write(
+            dir.path().join("node_modules/pkg/vendor.rs"),
+            b"fn vendor_old() {}",
+        )
+        .unwrap();
+
+        let (index, indexer) = setup(&dir);
+        write_meta_with_excludes(&dir, &[]); // empty: fall back to defaults
+
+        let (tx, rx) = mpsc::channel(16);
+        let handle = spawn_loop(rx, &dir, indexer, index.clone());
+
+        std::fs::write(
+            dir.path().join("node_modules/pkg/vendor.rs"),
+            b"fn vendor_new() {}",
+        )
+        .unwrap();
+        tx.send(dir.path().join("node_modules/pkg/vendor.rs"))
+            .await
+            .unwrap();
+        drop(tx);
+        handle.await.unwrap();
+
+        let names = symbol_names(&index).await;
+        assert!(names.iter().any(|n| n == "kept"));
+        assert!(!names.iter().any(|n| n == "vendor_new"), "names={names:?}");
     }
 }


### PR DESCRIPTION
## Problem
Watcher-driven indexing applied **no exclusions at all**:
- \`reindex_file\` re-indexed any changed path unconditionally, so a fixture excluded at initial indexing reappeared in the index as soon as it was edited.
- Full resync called \`index_project(root, &[])\` — dropping custom patterns and \`.gitignore\` entries.

## Changes
- **\`IndexMeta\`** (\`src/index/format.rs\`): new \`effective_excludes\` field (serde-defaulted for old metas) persisting the exact pattern list used at indexing time — custom patterns, defaults, and \`.gitignore\` entries.
- **\`src/indexer/mod.rs\`**: new \`path_is_excluded\` helper mirroring the initial-indexing walk filter (relative-path glob match + excluded directory-name components, including custom names); \`build_exclude_set\` made public.
- **\`src/watcher.rs\`**:
  - \`reindex_batch\` partitions changed paths through the persisted policy: excluded paths are **removed** from the index (handles the case where a file became excluded after being indexed), accepted paths are re-indexed in the same single-graph-rebuild batch as #79.
  - \`full_resync\` passes the persisted patterns to \`index_project\`; a fallback to defaults + \`.gitignore\` covers indexes created before this field existed.
- **\`src/tools/index_project.rs\`**: persists \`effective_excludes\`; the cached-path shortcut is invalidated when the computed exclusion set differs from the persisted one (so narrowing exclusions takes effect without \`force\`).

## Regression coverage
- Edit inside an excluded directory → not re-indexed; new file there → ignored.
- Previously indexed file that becomes excluded → removed on next watcher update.
- Full resync (overflow) respects the persisted policy.
- Built-in excluded names (\`node_modules\`) enforced even without persisted excludes.
- Changed excludes invalidate the cached index path; unchanged excludes still hit it.

Full suite: 628 passed; clippy and rustfmt clean.

Fixes #74