### PR TITLE
refactor: rename embed document truncate_chars to truncate_document

### DIFF
--- a/src/embed/document.rs
+++ b/src/embed/document.rs
@@ -49,7 +49,7 @@ fn env_usize(name: &str, default: usize) -> usize {
         .unwrap_or(default)
 }
 
-fn truncate_chars(text: &str, max: usize) -> String {
+fn truncate_document(text: &str, max: usize) -> String {
     if text.len() <= max {
         return text.to_string();
     }
@@ -70,7 +70,7 @@ fn compact_code(source: &str, max: usize) -> String {
     let tail = max - head;
     format!(
         "{}\n/* ... middle omitted ... */\n{}",
-        truncate_chars(source, head),
+        truncate_document(source, head),
         source
             .char_indices()
             .rev()
@@ -153,7 +153,7 @@ pub fn build_symbol_document(sym: &Symbol, project_root: Option<&Path>) -> Strin
         let mut parts = vec![sym.name.clone(), sym.qualified.clone()];
         parts.extend(sym.signature.iter().cloned());
         parts.extend(sym.doc.iter().cloned());
-        return truncate_chars(
+        return truncate_document(
             &parts.join("\n"),
             env_usize("PITLANE_EMBED_MAX_CHARS", DEFAULT_MAX_CHARS),
         );
@@ -197,7 +197,7 @@ pub fn build_symbol_document(sym: &Symbol, project_root: Option<&Path>) -> Strin
             env_usize("PITLANE_EMBED_BODY_CHARS", DEFAULT_BODY_CHARS),
         ));
     }
-    truncate_chars(
+    truncate_document(
         &text,
         env_usize("PITLANE_EMBED_MAX_CHARS", DEFAULT_MAX_CHARS),
     )


### PR DESCRIPTION
## Context
Two Rust functions shared the name \`truncate_chars\` (\`embed::document\` private helper and \`tools::orchestrator\`'s \`pub(crate)\` helper), making every bare call to that name lexically ambiguous in the navigation graph. This renames the private embed helper to \`truncate_document\` so the orchestrator helper resolves unambiguously — preparation for scope-aware call resolution (#85).

## Investigation note
While validating, I found that \`callers\`/\`callees\` return nothing for \`truncate_chars\` for a different reason: both call sites sit **inside \`format!\` macros**, which tree-sitter parses as raw token trees, so the Rust AST scan never sees them; the generic identifier path catches the edge but the pre-existing Rust policy caps non-AST evidence at 0.84 → classified as \`references\`. This predates #76 and is unaffected by this rename. A targeted follow-up could upgrade generic evidence when the identifier is directly followed by \`(\` in cleaned source (an actual call shape) — proposing that separately.

Full suite: 628 passed; clippy and rustfmt clean.