### PR TITLE
feat: add Git-diff impact analysis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Default public tier:
 - `read_code_unit`
 - `trace_path`
 - `analyze_impact`
+- `analyze_changes`
 - `get_index_stats`
 - `search_content`
 
@@ -27,7 +28,7 @@ Advanced primitive tools are hidden from `tools/list` unless the server is start
 2. Use `locate_code` when the user wants to find code but it is not yet clear whether the target is a symbol, file, or text fragment.
 3. Use `read_code_unit` once you know the target and want the smallest useful read instead of manually choosing between lower-level read primitives.
 4. Use `trace_path` for behavior, source-to-sink, config-to-effect, shortest-path, and other execution-path questions.
-5. Use `analyze_impact` for blast-radius questions before edits or refactors.
+5. Use `analyze_impact` for blast-radius questions before edits or refactors. Use `analyze_changes` to map a Git diff to revision-qualified symbols, impact evidence, and test candidates.
 6. Use `search_content` when you know a text snippet, log string, import path, macro name, or regex fragment but do not know the symbol boundary yet.
 7. Use `get_index_stats` to orient yourself in unfamiliar repos before broader exploration.
 8. Fall back to direct file reads only when editing or when full-file context is genuinely required.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,9 +105,9 @@ reqwest = { version = "0.12", default-features = false, features = [
 futures = "0.3"
 tree-sitter-solidity = "1.2"
 regex = "1"
+tempfile = "3"
 
 [dev-dependencies]
-tempfile = "3"
 criterion = { version = "0.8", features = ["html_reports"] }
 proptest = "1"
 httpmock = "0.8"

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Most users should stay on the default tool tier:
 3. Use `locate_code` when you need discovery without full source.
 4. Use `read_code_unit` once you know the target.
 5. Use `trace_path` for explicit source-to-sink or config-to-effect questions.
-6. Use `analyze_impact` before edits or refactors.
+6. Use `analyze_impact` before edits or refactors, and `analyze_changes` to review a Git diff.
 7. Use `search_content` only when you know a text fragment but not the owning symbol.
 
 Default public tier:
@@ -154,6 +154,7 @@ Default public tier:
 - `read_code_unit`
 - `trace_path`
 - `analyze_impact`
+- `analyze_changes`
 - `get_index_stats`
 - `search_content`
 
@@ -179,6 +180,7 @@ Examples:
 ```bash
 pitlane index /your/project
 pitlane investigate /your/project "How does ignore handling work?"
+pitlane analyze-changes /your/project --base-ref main --include-working-tree
 pitlane search /your/project authenticate --kind method
 pitlane symbol /your/project src/auth.rs::Auth::login[method]
 pitlane usages /your/project src/auth.rs::Auth::login[method]

--- a/docs/agent-guidance.md
+++ b/docs/agent-guidance.md
@@ -14,7 +14,7 @@ Use pitlane-mcp for code lookup whenever it is available.
 3. Use locate_code when you need discovery without full source.
 4. Use read_code_unit once you know the target.
 5. Use trace_path for explicit source-to-sink or config-to-effect questions.
-6. Use analyze_impact before edits or refactors.
+6. Use analyze_impact before edits or refactors; use analyze_changes to review Git-diff impact.
 7. Use search_content when you know a text fragment but not the owning symbol.
 8. Use get_index_stats for lightweight orientation before broader exploration.
 9. Fall back to direct file reads only when editing or when full-file context is genuinely required.
@@ -39,5 +39,6 @@ Default public tier:
 - `read_code_unit`
 - `trace_path`
 - `analyze_impact`
+- `analyze_changes`
 - `get_index_stats`
 - `search_content`

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -80,6 +80,36 @@ Estimate the blast radius of changing a symbol, file, or concept.
 
 Use this before edits or refactors.
 
+### `analyze_changes`
+
+Map a Git diff to changed symbols, likely affected graph neighbors, and test candidates.
+
+```json
+{ "project": "/your/project", "base_ref": "main", "include_working_tree": true }
+```
+
+CLI equivalent:
+
+```bash
+pitlane analyze-changes /your/project --base-ref main --include-working-tree
+```
+
+- `base_ref` is required and resolves to a commit. Comparison is directly against that commit, **not** its merge base with HEAD. Pass a merge-base SHA if that is what you need.
+- `include_working_tree` defaults to `false`: compare base with HEAD, ignoring staged/unstaged changes. When `true`, compare base with files on disk, including non-ignored untracked files. Staged content is included only as reflected on disk; this is not a staged-only diff.
+- Optional `depth` defaults to 2 (maximum 3); `limit` defaults to 8 (maximum 12 impacted symbols/files **per revision**).
+- No prior indexing or embeddings are required. Separate in-memory revision indexes reuse the existing weighted impact traversal without modifying Git state or the cached index.
+
+The response includes:
+
+- `base_revision`, `head_revision`, and `target_revision` (`working_tree` when applicable).
+- `changed_files` with zero-context `hunks`. Ranges use Git's one-based `start` and `count`; zero counts represent boundaries, not changed lines. Unmapped file changes remain visible, including `unmapped_hunk_indices` for partially mapped files.
+- `changed_symbols` with revision, line ranges, change classification, and supporting `hunk_indices` into that file's hunks. A modified symbol can appear for both revisions; symbol IDs must be interpreted together with `revision`.
+- `base_impact` and `target_impact` containing ranked `impact_symbols`, `impact_files`, support edges, and `test_candidates`. Base evidence preserves callers of deleted symbols. Base IDs and line ranges describe historical code, not necessarily readable current targets.
+- Graph results are labeled `heuristic`; support edges distinguish `heuristic_call` from `uncertain_reference`. Test candidates use test-like paths/names and graph evidence, **not** measured test coverage. Candidates come from the bounded impact list plus directly changed tests.
+- `omissions`, `effective_excludes`, and `limitations`. Impact results include total/omitted counts for the ranked lists.
+
+Renames appear as deletion/addition. Current exclusion policy applies to both revisions. Unsupported/excluded source and file-level edits may not map to symbols. Files over 1 MiB, symlinks, and submodules are omitted; snapshots are capped at 128 MiB each (use a project subtree for larger repos). Non-UTF-8 Git paths are rejected. Avoid editing files during analysis: worktree snapshots are not atomic.
+
 ### `get_index_stats`
 
 Return lightweight repo orientation data such as language and symbol counts.

--- a/src/bin/pitlane.rs
+++ b/src/bin/pitlane.rs
@@ -214,6 +214,21 @@ enum Command {
         #[arg(long)]
         limit: Option<usize>,
     },
+    /// Map a Git diff to symbols, affected graph neighbors, and test candidates
+    AnalyzeChanges {
+        /// Git project directory
+        project: String,
+        /// Commit, branch or tag to compare against HEAD
+        #[arg(long)]
+        base_ref: String,
+        /// Include files on disk and non-ignored untracked files
+        #[arg(long)]
+        include_working_tree: bool,
+        #[arg(long)]
+        depth: Option<usize>,
+        #[arg(long)]
+        limit: Option<usize>,
+    },
     /// Show token-efficiency statistics for get_symbol
     UsageStats {
         /// Path to the indexed project (omit for global totals)
@@ -519,6 +534,22 @@ async fn run_command(command: Command) -> anyhow::Result<serde_json::Value> {
             tools::orchestrator::trace_path(params).await?
         }
 
+        Command::AnalyzeChanges {
+            project,
+            base_ref,
+            include_working_tree,
+            depth,
+            limit,
+        } => {
+            tools::analyze_changes::analyze_changes(tools::analyze_changes::AnalyzeChangesParams {
+                project,
+                base_ref,
+                include_working_tree: Some(include_working_tree),
+                depth,
+                limit,
+            })
+            .await?
+        }
         Command::AnalyzeImpact {
             project,
             query,
@@ -638,6 +669,27 @@ mod tests {
             }
             other => panic!("unexpected command: {other:?}"),
         }
+    }
+
+    #[test]
+    fn clap_parses_analyze_changes_command() {
+        let cli = Cli::try_parse_from([
+            "pitlane",
+            "analyze-changes",
+            "/repo",
+            "--base-ref",
+            "main",
+            "--include-working-tree",
+            "--depth",
+            "3",
+            "--limit",
+            "10",
+        ])
+        .unwrap();
+        assert!(matches!(cli.command, Command::AnalyzeChanges {
+            project, base_ref, include_working_tree: true, depth: Some(3), limit: Some(10),
+        } if project == "/repo" && base_ref == "main"));
+        assert!(Cli::try_parse_from(["pitlane", "analyze-changes", "/repo"]).is_err());
     }
 
     #[test]

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -130,6 +130,14 @@ impl CandidateIndex {
 }
 
 pub fn build_navigation_graph(index: &SymbolIndex) -> NavigationGraph {
+    build_navigation_graph_with_source(index, |sym| read_symbol_source(sym, false))
+}
+
+/// Build the same navigation graph from a revision snapshot without reading the worktree.
+pub(crate) fn build_navigation_graph_with_source(
+    index: &SymbolIndex,
+    source: impl Fn(&Symbol) -> anyhow::Result<String>,
+) -> NavigationGraph {
     let mut graph = NavigationGraph {
         built: true,
         ..Default::default()
@@ -137,7 +145,7 @@ pub fn build_navigation_graph(index: &SymbolIndex) -> NavigationGraph {
 
     let candidates = CandidateIndex::build(index);
     for sym in index.symbols.values() {
-        let source_text = match read_symbol_source(sym, false) {
+        let source_text = match source(sym) {
             Ok(source) => source,
             Err(_) => continue,
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,6 +198,20 @@ pub struct TracePathRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct AnalyzeChangesRequest {
+    /// Git project directory; a cached index is not required.
+    pub project: String,
+    /// Commit, branch or tag to compare against HEAD (not a merge-base comparison).
+    pub base_ref: String,
+    /// Compare with files on disk, including non-ignored untracked files (default false).
+    pub include_working_tree: Option<bool>,
+    /// Maximum graph traversal depth (default 2, maximum 3).
+    pub depth: Option<usize>,
+    /// Maximum impacted symbols/files per revision (default 8, maximum 12).
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct AnalyzeImpactRequest {
     /// Project path previously indexed
     pub project: String,
@@ -381,6 +395,7 @@ const DEFAULT_PUBLIC_TOOL_NAMES: &[&str] = &[
     "read_code_unit",
     "trace_path",
     "analyze_impact",
+    "analyze_changes",
     "get_index_stats",
     "search_content",
 ];
@@ -776,6 +791,33 @@ impl PitlaneMcp {
     }
 
     #[tool(
+        description = "Analyze a Git diff against base_ref. Maps edited lines to symbols and returns revision-qualified impact evidence and test candidates, including deleted symbols from the base revision. Does not require a cached index.",
+        meta = tool_meta("git diff changes impact callers tests review"),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn analyze_changes(&self, Parameters(req): Parameters<AnalyzeChangesRequest>) -> String {
+        match tools::analyze_changes::analyze_changes(
+            tools::analyze_changes::AnalyzeChangesParams {
+                project: req.project,
+                base_ref: req.base_ref,
+                include_working_tree: req.include_working_tree,
+                depth: req.depth,
+                limit: req.limit,
+            },
+        )
+        .await
+        {
+            Ok(v) => value_to_text(v),
+            Err(e) => err_to_text(e),
+        }
+    }
+
+    #[tool(
         description = "Advanced umbrella router across locate, read, trace, and impact. Prefer locate_code or trace_path unless you want the server to choose the workflow.",
         meta = tool_meta("navigate locate read trace impact route intent"),
         annotations(
@@ -1137,8 +1179,8 @@ impl ServerHandler for PitlaneMcp {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_instructions(
                 "pitlane-mcp: token-efficient code navigation. \
-                Default tool tier: ensure_project_ready, investigate, locate_code, read_code_unit, trace_path, analyze_impact, get_index_stats, and search_content. \
-                Suggested flow: start with ensure_project_ready; use investigate for broad code questions; use locate_code for ambiguous discovery; use read_code_unit to inspect a chosen target; use trace_path for flow questions; use analyze_impact before edits; use get_index_stats for lightweight orientation; use search_content only when you know a text fragment. \
+                Default tool tier: ensure_project_ready, investigate, locate_code, read_code_unit, trace_path, analyze_impact, analyze_changes, get_index_stats, and search_content. \
+                Suggested flow: start with ensure_project_ready; use investigate for broad code questions; use locate_code for ambiguous discovery; use read_code_unit to inspect a chosen target; use trace_path for flow questions; use analyze_impact before edits and analyze_changes for Git-diff impact; use get_index_stats for lightweight orientation; use search_content only when you know a text fragment. \
                 Advanced primitive tools are hidden from tools/list by default to reduce agent branching. Set PITLANE_MCP_TOOL_TIER=all to expose the full primitive surface.",
             )
     }

--- a/src/tools/analyze_changes.rs
+++ b/src/tools/analyze_changes.rs
@@ -1,0 +1,574 @@
+//! Revision-local Git diff analysis. Never checks out files or mutates the cached index.
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use serde_json::{json, Value};
+
+use crate::index::SymbolIndex;
+use crate::indexer::{self, language::Symbol, registry::build_default_registry, Indexer};
+use crate::path_policy::{open_regular_file, regular_file_metadata, resolve_project_path};
+use crate::tools::orchestrator::{impact_from_seeds, AnalyzeImpactParams, ImpactSeed};
+
+#[cfg(test)]
+mod tests;
+
+const MAX_FILE_BYTES: usize = 1024 * 1024;
+const MAX_SNAPSHOT_BYTES: usize = 128 * 1024 * 1024;
+
+pub struct AnalyzeChangesParams {
+    pub project: String,
+    pub base_ref: String,
+    pub include_working_tree: Option<bool>,
+    pub depth: Option<usize>,
+    pub limit: Option<usize>,
+}
+
+pub async fn analyze_changes(params: AnalyzeChangesParams) -> Result<Value> {
+    tokio::task::spawn_blocking(move || analyze(params)).await?
+}
+
+fn git(root: &Path, args: &[&str]) -> Result<Vec<u8>> {
+    let output = Command::new("git")
+        .current_dir(root)
+        .args(args)
+        .env("GIT_OPTIONAL_LOCKS", "0")
+        .output()
+        .context("analyze_changes requires Git")?;
+    anyhow::ensure!(
+        output.status.success(),
+        "Git failed: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+    Ok(output.stdout)
+}
+
+fn resolve_commit(root: &Path, revision: &str) -> Result<String> {
+    anyhow::ensure!(!revision.trim().is_empty(), "base_ref must not be empty");
+    let bytes = git(
+        root,
+        &[
+            "rev-parse",
+            "--verify",
+            "--end-of-options",
+            &format!("{revision}^{{commit}}"),
+        ],
+    )?;
+    Ok(String::from_utf8(bytes)?.trim().to_string())
+}
+
+#[derive(Default)]
+struct Snapshot {
+    files: BTreeMap<PathBuf, Vec<u8>>,
+    omissions: Vec<Value>,
+    unavailable: BTreeSet<PathBuf>,
+    bytes: usize,
+}
+
+impl Snapshot {
+    fn insert(&mut self, path: PathBuf, bytes: Vec<u8>) -> Result<()> {
+        self.bytes += bytes.len();
+        anyhow::ensure!(
+            self.bytes <= MAX_SNAPSHOT_BYTES,
+            "Revision snapshot exceeds the 128 MiB analysis limit; use a smaller project subtree"
+        );
+        self.files.insert(path, bytes);
+        Ok(())
+    }
+
+    fn omit(&mut self, path: &Path, reason: &str) {
+        self.unavailable.insert(path.to_path_buf());
+        self.omissions.push(json!({"file": path, "reason": reason}));
+    }
+}
+
+fn safe_relative(path: &str) -> Result<PathBuf> {
+    let path = PathBuf::from(path);
+    anyhow::ensure!(
+        !path.as_os_str().is_empty()
+            && path.components().all(|c| matches!(c, Component::Normal(_))),
+        "Unsupported Git path: {}",
+        path.display()
+    );
+    Ok(path)
+}
+
+fn revision_snapshot(root: &Path, repo: &Path, revision: &str) -> Result<Snapshot> {
+    let prefix = root.strip_prefix(repo)?;
+    let listing = git(
+        repo,
+        &["ls-tree", "-r", "-l", "-z", "--full-tree", revision],
+    )?;
+    let mut snapshot = Snapshot::default();
+    for entry in listing.split(|b| *b == 0).filter(|e| !e.is_empty()) {
+        let entry = std::str::from_utf8(entry).context("Non-UTF-8 Git paths are not supported")?;
+        let (metadata, path) = entry.split_once('\t').context("Invalid Git tree entry")?;
+        let path = safe_relative(path)?;
+        let Ok(relative) = path.strip_prefix(prefix) else {
+            continue;
+        };
+        let fields: Vec<_> = metadata.split_whitespace().collect();
+        anyhow::ensure!(fields.len() == 4, "Invalid Git tree metadata");
+        if !matches!(fields[0], "100644" | "100755") || fields[1] != "blob" {
+            snapshot.omit(relative, "symlink or submodule");
+            continue;
+        }
+        if fields[3].parse::<usize>()? > MAX_FILE_BYTES {
+            snapshot.omit(relative, "file exceeds 1 MiB");
+            continue;
+        }
+        snapshot.insert(
+            relative.to_path_buf(),
+            git(repo, &["cat-file", "blob", fields[2]])?,
+        )?;
+    }
+    Ok(snapshot)
+}
+
+fn working_snapshot(root: &Path) -> Result<Snapshot> {
+    let listing = git(
+        root,
+        &[
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "-z",
+            "--",
+            ".",
+        ],
+    )?;
+    let mut snapshot = Snapshot::default();
+    let mut seen = BTreeSet::new();
+    for entry in listing.split(|b| *b == 0).filter(|e| !e.is_empty()) {
+        let relative = safe_relative(
+            std::str::from_utf8(entry).context("Non-UTF-8 Git paths are not supported")?,
+        )?;
+        if !seen.insert(relative.clone()) {
+            continue;
+        }
+        let path = root.join(&relative);
+        // Refuse intermediate symlinks too, including links pointing inside the project.
+        let mut ancestor = root.to_path_buf();
+        let mut symlink = false;
+        for part in relative.components() {
+            ancestor.push(part);
+            if std::fs::symlink_metadata(&ancestor).is_ok_and(|m| m.file_type().is_symlink()) {
+                symlink = true;
+                break;
+            }
+        }
+        if symlink {
+            snapshot.omit(&relative, "symlink");
+            continue;
+        }
+        let Some(metadata) = regular_file_metadata(&path)? else {
+            continue;
+        };
+        if metadata.len() > MAX_FILE_BYTES as u64 {
+            snapshot.omit(&relative, "file exceeds 1 MiB");
+            continue;
+        }
+        use std::io::Read;
+        let mut bytes = Vec::new();
+        open_regular_file(&path)?
+            .take(MAX_FILE_BYTES as u64 + 1)
+            .read_to_end(&mut bytes)?;
+        if bytes.len() > MAX_FILE_BYTES {
+            snapshot.omit(&relative, "file exceeds 1 MiB");
+            continue;
+        }
+        snapshot.insert(relative, bytes)?;
+    }
+    Ok(snapshot)
+}
+
+fn snapshot_index(
+    root: &Path,
+    snapshot: &mut Snapshot,
+    excludes: &globset::GlobSet,
+) -> Result<SymbolIndex> {
+    let registry = build_default_registry();
+    let extra = indexer::extra_excluded_dir_names();
+    let mut index = SymbolIndex::new();
+    for (relative, source) in &snapshot.files {
+        let absolute = root.join(relative);
+        let ext = relative.extension().and_then(|e| e.to_str()).unwrap_or("");
+        if indexer::path_is_excluded(&absolute, root, excludes, &extra)
+            || excludes.is_match(&absolute)
+            || indexer::is_declaration_file(relative)
+        {
+            continue;
+        }
+        let Some(parser) = registry.iter().find(|p| p.extensions().contains(&ext)) else {
+            continue;
+        };
+        let Some(language) = indexer::tree_sitter_language_for_extension(ext) else {
+            continue;
+        };
+        let mut ts = tree_sitter::Parser::new();
+        ts.set_language(&language)?;
+        let Some(tree) = ts.parse(source, None) else {
+            snapshot
+                .omissions
+                .push(json!({"file": relative, "reason": "parse failed"}));
+            continue;
+        };
+        if tree.root_node().has_error() {
+            snapshot.omissions.push(
+                json!({"file": relative, "reason": "parse errors; symbols may be incomplete"}),
+            );
+        }
+        for mut symbol in parser.extract_symbols(source, &tree, relative) {
+            symbol.file = Arc::new(absolute.clone());
+            index.insert(symbol);
+        }
+    }
+    index.graph = crate::graph::build_navigation_graph_with_source(&index, |symbol| {
+        let source = snapshot
+            .files
+            .get(symbol.file.strip_prefix(root)?)
+            .context("Missing revision source")?;
+        let body = source
+            .get(symbol.byte_start..symbol.byte_end)
+            .context("Invalid symbol byte range")?;
+        Ok(String::from_utf8_lossy(body).into_owned())
+    });
+    Ok(index)
+}
+
+#[derive(Clone, Copy, Debug, serde::Serialize)]
+struct LineRange {
+    start: u32,
+    count: u32,
+}
+
+impl LineRange {
+    fn overlaps(self, symbol: &Symbol) -> bool {
+        // A zero-length range is an insertion/deletion boundary, not an edited line.
+        self.count > 0
+            && self.start <= symbol.line_end
+            && self.start.saturating_add(self.count - 1) >= symbol.line_start
+    }
+}
+
+#[derive(Debug, serde::Serialize)]
+struct Hunk {
+    old: LineRange,
+    new: LineRange,
+}
+
+fn parse_range(range: &str) -> Result<LineRange> {
+    let (start, count) = range.split_once(',').unwrap_or((range, "1"));
+    Ok(LineRange {
+        start: start.parse()?,
+        count: count.parse()?,
+    })
+}
+
+fn parse_hunks(diff: &[u8]) -> Result<Vec<Hunk>> {
+    let mut hunks = Vec::new();
+    for line in String::from_utf8_lossy(diff)
+        .lines()
+        .filter(|line| line.starts_with("@@ "))
+    {
+        let mut fields = line.split_whitespace().skip(1);
+        let old = fields
+            .next()
+            .and_then(|s| s.strip_prefix('-'))
+            .context("Invalid old hunk range")?;
+        let new = fields
+            .next()
+            .and_then(|s| s.strip_prefix('+'))
+            .context("Invalid new hunk range")?;
+        hunks.push(Hunk {
+            old: parse_range(old)?,
+            new: parse_range(new)?,
+        });
+    }
+    Ok(hunks)
+}
+
+fn diff_hunks(root: &Path, old: &[u8], new: &[u8]) -> Result<Vec<Hunk>> {
+    use std::io::Write;
+    let mut before = tempfile::NamedTempFile::new()?;
+    let mut after = tempfile::NamedTempFile::new()?;
+    before.write_all(old)?;
+    after.write_all(new)?;
+    let output = Command::new("git")
+        .current_dir(root)
+        .args([
+            "diff",
+            "--no-index",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--text",
+            "--no-color",
+            "--unified=0",
+            "--inter-hunk-context=0",
+            "--diff-algorithm=myers",
+            "--",
+        ])
+        .arg(before.path())
+        .arg(after.path())
+        .output()?;
+    anyhow::ensure!(
+        matches!(output.status.code(), Some(0 | 1)),
+        "Git diff failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    parse_hunks(&output.stdout)
+}
+
+fn seed(symbol: &Symbol) -> ImpactSeed {
+    ImpactSeed {
+        id: symbol.id.clone(),
+        name: symbol.name.clone(),
+        kind: symbol.kind.to_string(),
+        file: symbol.file.to_string_lossy().into_owned(),
+    }
+}
+
+fn symbol_value(symbol: &Symbol, revision: &str, change: &str, hunks: &[usize]) -> Value {
+    json!({"id": symbol.id, "name": symbol.name, "kind": symbol.kind.to_string(),
+        "file": symbol.file, "line_start": symbol.line_start, "line_end": symbol.line_end,
+        "revision": revision, "change": change, "hunk_indices": hunks,
+        "evidence": "symbol line range overlaps changed lines"})
+}
+
+fn revision_impact(
+    params: &AnalyzeChangesParams,
+    root: &Path,
+    index: &SymbolIndex,
+    seeds: Vec<ImpactSeed>,
+    revision: &str,
+) -> Result<Value> {
+    if seeds.is_empty() {
+        return Ok(json!({
+            "revision": revision, "certainty": "heuristic",
+            "seed_symbols": [], "impact_symbols": [], "impact_files": [], "test_candidates": [],
+            "depth_limit": params.depth.unwrap_or(2).clamp(1, 3),
+            "limit": params.limit.unwrap_or(8).clamp(1, 12),
+            "total_impact_symbols": 0, "total_impact_files": 0,
+            "omitted_impact_symbols": 0, "omitted_impact_files": 0,
+        }));
+    }
+    let profile = crate::index::repo_profile::build_repo_profile(root, index);
+    let mut result = impact_from_seeds(
+        &AnalyzeImpactParams {
+            project: params.project.clone(),
+            query: None,
+            symbol_id: None,
+            file_path: None,
+            scope: None,
+            depth: params.depth,
+            limit: params.limit,
+        },
+        index,
+        root,
+        &seeds,
+        Some(&profile),
+        false,
+    )?;
+    // Historical IDs can equal current IDs; always qualify graph evidence by revision.
+    result.as_object_mut().unwrap().remove("steering");
+    result["revision"] = json!(revision);
+    result["certainty"] = json!("heuristic");
+    for key in ["impact_symbols", "impact_files"] {
+        for item in result[key].as_array_mut().unwrap() {
+            item["revision"] = json!(revision);
+            item["certainty"] = json!("heuristic");
+            if let Some(edges) = item["support_edges"].as_array_mut() {
+                for edge in edges {
+                    edge["certainty"] = json!(if edge["relation"] == "calls" {
+                        "heuristic_call"
+                    } else {
+                        "uncertain_reference"
+                    });
+                }
+            }
+        }
+    }
+    // Include directly changed tests as well as graph-reachable test candidates.
+    let mut tests = BTreeMap::new();
+    for symbol in result["impact_symbols"].as_array().unwrap() {
+        if let Some(sym) = symbol["id"].as_str().and_then(|id| index.symbols.get(id)) {
+            if is_test(sym, root, index) {
+                let mut candidate = symbol.clone();
+                candidate["test_evidence"] =
+                    json!("test-like path or symbol name; impact supported by graph edges");
+                tests.insert(sym.id.clone(), candidate);
+            }
+        }
+    }
+    for seed in seeds {
+        let sym = &index.symbols[&seed.id];
+        if is_test(sym, root, index) {
+            let candidate = tests.entry(seed.id).or_insert_with(|| {
+                json!({
+                    "id": sym.id, "name": sym.name, "file": sym.file,
+                    "revision": revision, "certainty": "heuristic",
+                    "test_evidence": "test-like path or symbol name",
+                })
+            });
+            candidate["change_evidence"] = json!("symbol line range overlaps changed lines");
+        }
+    }
+    result["test_candidates"] = json!(tests.into_values().collect::<Vec<_>>());
+    Ok(result)
+}
+
+fn is_test(symbol: &Symbol, root: &Path, index: &SymbolIndex) -> bool {
+    use crate::index::repo_profile::{classify_path_role, PathRole};
+    classify_path_role(
+        symbol.file.strip_prefix(root).unwrap_or(&symbol.file),
+        index,
+    ) == PathRole::Test
+        || symbol.name.starts_with("test_")
+        || symbol.name.ends_with("_test")
+        || symbol.qualified.contains("tests::")
+        || symbol.qualified.contains("Test")
+}
+
+fn analyze(params: AnalyzeChangesParams) -> Result<Value> {
+    let root = resolve_project_path(&params.project)?;
+    let repo_output = String::from_utf8(git(&root, &["rev-parse", "--show-toplevel"])?)?;
+    let repo = PathBuf::from(repo_output.strip_suffix('\n').unwrap_or(&repo_output));
+    let repo = repo.canonicalize()?;
+    let base = resolve_commit(&root, &params.base_ref)?;
+    let head = resolve_commit(&root, "HEAD")?;
+    let include_working_tree = params.include_working_tree.unwrap_or(false);
+    let target_revision = if include_working_tree {
+        "working_tree"
+    } else {
+        &head
+    };
+    let mut before = revision_snapshot(&root, &repo, &base)?;
+    let mut after = if include_working_tree {
+        working_snapshot(&root)?
+    } else {
+        revision_snapshot(&root, &repo, &head)?
+    };
+    let mut patterns = indexer::default_exclude_patterns();
+    patterns.extend(indexer::load_gitignore_patterns(&root));
+    if let Ok(meta) = crate::index::format::load_project_meta(&root) {
+        patterns.extend(meta.effective_excludes);
+    }
+    let excludes = Indexer::build_exclude_set(&patterns)?;
+    let old_index = snapshot_index(&root, &mut before, &excludes)?;
+    let new_index = snapshot_index(&root, &mut after, &excludes)?;
+    let paths: BTreeSet<_> = before.files.keys().chain(after.files.keys()).collect();
+    let mut files = Vec::new();
+    let mut changed_symbols = Vec::new();
+    let mut old_seeds = BTreeMap::new();
+    let mut new_seeds = BTreeMap::new();
+    for path in paths {
+        let old = before.files.get(path);
+        let new = after.files.get(path);
+        if old == new {
+            continue;
+        }
+        // Do not turn an unreadable/oversized target into a claimed deletion.
+        if before.unavailable.contains(path) || after.unavailable.contains(path) {
+            continue;
+        }
+        let hunks = diff_hunks(
+            &root,
+            old.map(Vec::as_slice).unwrap_or_default(),
+            new.map(Vec::as_slice).unwrap_or_default(),
+        )?;
+        let change = if old.is_none() {
+            "added"
+        } else if new.is_none() {
+            "deleted"
+        } else {
+            "modified"
+        };
+        let absolute = root.join(path);
+        let start = changed_symbols.len();
+        let mut mapped_hunks = BTreeSet::new();
+        for (index, other, revision, is_old, seeds) in [
+            (&old_index, &new_index, base.as_str(), true, &mut old_seeds),
+            (
+                &new_index,
+                &old_index,
+                target_revision,
+                false,
+                &mut new_seeds,
+            ),
+        ] {
+            let mut symbols: Vec<_> = index
+                .by_file
+                .get(&absolute)
+                .into_iter()
+                .flatten()
+                .filter_map(|id| index.symbols.get(id))
+                .collect();
+            symbols.sort_by(|a, b| a.line_start.cmp(&b.line_start).then(a.id.cmp(&b.id)));
+            for symbol in symbols {
+                let overlaps: Vec<_> = hunks
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(i, h)| {
+                        if (if is_old { h.old } else { h.new }).overlaps(symbol) {
+                            Some(i)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                if overlaps.is_empty() {
+                    continue;
+                }
+                let change = if other.symbols.contains_key(&symbol.id) {
+                    "modified"
+                } else if is_old {
+                    "deleted"
+                } else {
+                    "added"
+                };
+                mapped_hunks.extend(overlaps.iter().copied());
+                changed_symbols.push(symbol_value(symbol, revision, change, &overlaps));
+                seeds.insert(symbol.id.clone(), seed(symbol));
+            }
+        }
+        let unmapped_hunks: Vec<_> = (0..hunks.len())
+            .filter(|i| !mapped_hunks.contains(i))
+            .collect();
+        files.push(json!({"file": path, "change": change, "hunks": hunks,
+            "unmapped_hunk_indices": unmapped_hunks,
+            "mapped_symbol_count": changed_symbols.len() - start,
+            "unmapped_reason": if start == changed_symbols.len() { Some("No indexed symbol overlaps these lines (unsupported, excluded, or file-level change)") } else { None }}));
+    }
+    let base_impact = revision_impact(
+        &params,
+        &root,
+        &old_index,
+        old_seeds.into_values().collect(),
+        &base,
+    )?;
+    let target_impact = revision_impact(
+        &params,
+        &root,
+        &new_index,
+        new_seeds.into_values().collect(),
+        target_revision,
+    )?;
+    Ok(json!({
+        "base_ref": params.base_ref, "base_revision": base, "head_revision": head,
+        "effective_excludes": patterns,
+        "target_revision": target_revision, "include_working_tree": include_working_tree,
+        "changed_files": files, "changed_symbols": changed_symbols,
+        "base_impact": base_impact, "target_impact": target_impact,
+        "omissions": {"base": before.omissions, "target": after.omissions},
+        "limitations": [
+            "Graph edges and test classification are heuristic, not proof of runtime impact or test coverage.",
+            "Impact lists are ranked and bounded by limit (default 8, maximum 12) and depth (default 2, maximum 3); test candidates come from those results and changed tests.",
+            "Renames are represented as deletion/addition. File-level edits outside symbol ranges remain unmapped.",
+            "Exclusions use the current project policy for both revisions. Files over 1 MiB, symlinks and submodules are omitted.",
+            "Working-tree snapshots are not atomic; do not edit files during analysis. Staged content is included only as reflected in files on disk."
+        ]
+    }))
+}

--- a/src/tools/analyze_changes/tests.rs
+++ b/src/tools/analyze_changes/tests.rs
@@ -1,0 +1,340 @@
+use super::*;
+use tempfile::TempDir;
+
+fn fixture() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    git(dir.path(), &["init", "-q"]).unwrap();
+    write(
+        &dir,
+        "lib.rs",
+        "pub fn compute() -> i32 {\n    1\n}\npub fn caller() -> i32 {\n    compute()\n}\n",
+    );
+    write(
+        &dir,
+        "tests/check.rs",
+        "fn test_compute() {\n    compute();\n}\n",
+    );
+    commit(&dir);
+    dir
+}
+
+fn write(dir: &TempDir, path: &str, content: &str) {
+    let path = dir.path().join(path);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, content).unwrap();
+}
+
+fn commit(dir: &TempDir) {
+    git(dir.path(), &["add", "--all"]).unwrap();
+    git(
+        dir.path(),
+        &[
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "-qm",
+            "fixture",
+        ],
+    )
+    .unwrap();
+}
+
+fn run(dir: &TempDir, base: &str, worktree: bool) -> Value {
+    analyze(AnalyzeChangesParams {
+        project: dir.path().display().to_string(),
+        base_ref: base.to_string(),
+        include_working_tree: Some(worktree),
+        depth: Some(2),
+        limit: Some(12),
+    })
+    .unwrap()
+}
+
+#[test]
+fn hunk_ranges_include_defaults_and_zero_length() {
+    let hunks = parse_hunks(b"@@ -2 +2,3 @@\n-old\n+new\n@@ -9,0 +12 @@\n+x\n").unwrap();
+    assert_eq!(hunks.len(), 2);
+    assert_eq!(hunks[0].old.count, 1);
+    assert_eq!(hunks[0].new.count, 3);
+    assert_eq!(hunks[1].old.count, 0);
+    assert_eq!(hunks[1].new.start, 12);
+}
+
+#[test]
+fn clean_tree_and_invalid_revision() {
+    let dir = fixture();
+    let result = run(&dir, "HEAD", false);
+    assert_eq!(result["changed_files"], json!([]));
+    assert_eq!(result["changed_symbols"], json!([]));
+    assert_eq!(result["base_impact"]["impact_symbols"], json!([]));
+    for revision in ["", "missing-ref", "--help"] {
+        assert!(resolve_commit(dir.path(), revision).is_err());
+    }
+    let nongit = TempDir::new().unwrap();
+    assert!(analyze(AnalyzeChangesParams {
+        project: nongit.path().display().to_string(),
+        base_ref: "HEAD".into(),
+        include_working_tree: None,
+        depth: None,
+        limit: None,
+    })
+    .is_err());
+}
+
+#[test]
+fn committed_change_ignores_worktree_and_reuses_impact_evidence() {
+    let dir = fixture();
+    write(
+        &dir,
+        "lib.rs",
+        "pub fn compute() -> i32 {\n    2\n}\npub fn caller() -> i32 {\n    compute()\n}\n",
+    );
+    commit(&dir);
+    write(&dir, "lib.rs", "pub fn unrelated() {}\n");
+    let result = run(&dir, "HEAD~1", false);
+    let changed = result["changed_symbols"].as_array().unwrap();
+    assert_eq!(changed.len(), 2);
+    assert!(changed
+        .iter()
+        .all(|s| s["name"] == "compute" && s["change"] == "modified"));
+    let impact = result["target_impact"]["impact_symbols"]
+        .as_array()
+        .unwrap();
+    let caller = impact.iter().find(|s| s["name"] == "caller").unwrap();
+    assert_eq!(caller["certainty"], "heuristic");
+    assert!(!caller["support_edges"].as_array().unwrap().is_empty());
+    assert!(result["target_impact"]["test_candidates"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|s| s["name"] == "test_compute"));
+    assert!(!result.to_string().contains("unrelated"));
+    assert!(result["changed_files"][0]["hunks"][0]["old"]["start"] == 2);
+}
+
+#[test]
+fn deleted_symbol_uses_base_graph_even_when_current_calls_are_unresolved() {
+    let dir = fixture();
+    write(
+        &dir,
+        "lib.rs",
+        "pub fn caller() -> i32 {\n    compute()\n}\n",
+    );
+    let result = run(&dir, "HEAD", true);
+    assert!(result["changed_symbols"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|s| s["name"] == "compute" && s["change"] == "deleted"));
+    assert!(result["base_impact"]["impact_symbols"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|s| s["name"] == "caller"));
+    assert!(result["base_impact"]["test_candidates"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|s| s["name"] == "test_compute"));
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("lib.rs")).unwrap(),
+        "pub fn caller() -> i32 {\n    compute()\n}\n"
+    );
+}
+
+#[test]
+fn staged_unstaged_untracked_and_ignored_files() {
+    let dir = fixture();
+    write(&dir, ".gitignore", "ignored.rs\n");
+    write(&dir, "ignored.rs", "fn ignored() {}\n");
+    write(&dir, "new file.rs", "fn fresh() {}\n");
+    write(&dir, "lib.rs", "fn staged() {}\n");
+    git(dir.path(), &["add", "lib.rs"]).unwrap();
+    write(&dir, "lib.rs", "fn unstaged() {}\n");
+    let before = git(dir.path(), &["status", "--porcelain=v1", "-z"]).unwrap();
+    let result = run(&dir, "HEAD", true);
+    let changed = result["changed_symbols"].as_array().unwrap();
+    assert!(changed.iter().any(|s| s["name"] == "unstaged"));
+    assert!(changed.iter().any(|s| s["name"] == "fresh"));
+    assert!(!changed
+        .iter()
+        .any(|s| s["name"] == "staged" || s["name"] == "ignored"));
+    assert_eq!(
+        before,
+        git(dir.path(), &["status", "--porcelain=v1", "-z"]).unwrap()
+    );
+    assert_eq!(run(&dir, "HEAD", false)["changed_files"], json!([]));
+}
+
+#[test]
+fn deleted_files_renames_and_unmapped_documentation() {
+    let dir = fixture();
+    std::fs::rename(dir.path().join("lib.rs"), dir.path().join("renamed.rs")).unwrap();
+    write(&dir, "README.md", "# Hello\n");
+    let result = run(&dir, "HEAD", true);
+    let files = result["changed_files"].as_array().unwrap();
+    assert!(files
+        .iter()
+        .any(|f| f["file"] == "lib.rs" && f["change"] == "deleted"));
+    assert!(files
+        .iter()
+        .any(|f| f["file"] == "renamed.rs" && f["change"] == "added"));
+    assert!(files.iter().any(|f| f["file"] == "README.md"
+        && f["mapped_symbol_count"] == 0
+        && f["unmapped_reason"].is_string()));
+}
+
+#[test]
+fn subtree_analysis_does_not_include_siblings() {
+    let dir = fixture();
+    write(&dir, "package/lib.rs", "fn inner() {\n    let a = 1;\n}\n");
+    commit(&dir);
+    write(&dir, "package/lib.rs", "fn inner() {\n    let a = 2;\n}\n");
+    write(&dir, "lib.rs", "fn outside() {}\n");
+    let result = analyze(AnalyzeChangesParams {
+        project: dir.path().join("package").display().to_string(),
+        base_ref: "HEAD".into(),
+        include_working_tree: Some(true),
+        depth: None,
+        limit: None,
+    })
+    .unwrap();
+    assert_eq!(result["changed_files"].as_array().unwrap().len(), 1);
+    assert!(result["changed_symbols"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|s| s["name"] == "inner"));
+}
+
+#[test]
+fn zero_length_boundary_does_not_mark_neighboring_symbol() {
+    let dir = fixture();
+    write(&dir, "lib.rs", "pub fn compute() -> i32 {\n    1\n}\nfn inserted() {}\npub fn caller() -> i32 {\n    compute()\n}\n");
+    let result = run(&dir, "HEAD", true);
+    let changed = result["changed_symbols"].as_array().unwrap();
+    assert_eq!(changed.len(), 1);
+    assert_eq!(changed[0]["name"], "inserted");
+    assert_eq!(changed[0]["change"], "added");
+}
+
+#[test]
+fn exclusions_and_parse_errors_are_reported_without_hiding_changes() {
+    let dir = fixture();
+    write(&dir, "generated.rs", "fn generated() {}\n");
+    write(&dir, "node_modules/vendor.rs", "fn vendor() {}\n");
+    commit(&dir);
+    write(&dir, "generated.rs", "fn generated_new() {}\n");
+    write(&dir, "node_modules/vendor.rs", "fn vendor_new() {}\n");
+    write(&dir, "broken.rs", "fn broken() { let = ; }\n");
+    let mut meta = crate::index::format::IndexMeta::new(dir.path());
+    meta.effective_excludes = vec!["generated.rs".into()];
+    let index_dir = crate::index::format::index_dir(dir.path()).unwrap();
+    std::fs::create_dir_all(&index_dir).unwrap();
+    crate::index::format::save_meta(&meta, &index_dir.join("meta.json")).unwrap();
+    let result = run(&dir, "HEAD", true);
+    let changed = result["changed_symbols"].as_array().unwrap();
+    assert!(!changed
+        .iter()
+        .any(|s| s["name"] == "generated_new" || s["name"] == "vendor_new"));
+    assert!(result["changed_files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|f| f["file"] == "broken.rs"));
+    assert!(result["omissions"]["target"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|o| o["file"] == "broken.rs"));
+    assert!(result["effective_excludes"]
+        .as_array()
+        .unwrap()
+        .contains(&json!("generated.rs")));
+}
+
+#[test]
+fn bounded_results_report_omissions_and_label_uncertain_references() {
+    let dir = fixture();
+    write(&dir, "lib.rs", "pub fn compute() -> i32 {\n    1\n}\nfn indirect() { let callback = compute; }\nfn caller_one() { compute(); }\nfn caller_two() { compute(); }\n");
+    commit(&dir);
+    write(&dir, "lib.rs", "pub fn compute() -> i32 {\n    2\n}\nfn indirect() { let callback = compute; }\nfn caller_one() { compute(); }\nfn caller_two() { compute(); }\n");
+    let result = run(&dir, "HEAD", true);
+    let indirect = result["target_impact"]["impact_symbols"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|s| s["name"] == "indirect")
+        .unwrap();
+    assert!(indirect["support_edges"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|e| e["certainty"] == "uncertain_reference"));
+    let limited = analyze(AnalyzeChangesParams {
+        project: dir.path().display().to_string(),
+        base_ref: "HEAD".into(),
+        include_working_tree: Some(true),
+        depth: Some(1),
+        limit: Some(1),
+    })
+    .unwrap();
+    assert_eq!(
+        limited["target_impact"]["impact_symbols"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+    assert!(
+        limited["target_impact"]["omitted_impact_symbols"]
+            .as_u64()
+            .unwrap()
+            > 0
+    );
+}
+
+#[test]
+fn oversized_file_is_not_reported_as_a_deletion() {
+    let dir = fixture();
+    write(&dir, "lib.rs", &"x".repeat(MAX_FILE_BYTES + 1));
+    let result = run(&dir, "HEAD", true);
+    assert!(result["omissions"]["target"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|o| o["file"] == "lib.rs"));
+    assert_eq!(result["changed_symbols"], json!([]));
+}
+
+#[cfg(unix)]
+#[test]
+fn symlinks_are_not_followed() {
+    use std::os::unix::fs::symlink;
+    let dir = fixture();
+    let external = TempDir::new().unwrap();
+    write(&external, "secret.rs", "fn secret() {}\n");
+    symlink(
+        external.path().join("secret.rs"),
+        dir.path().join("link.rs"),
+    )
+    .unwrap();
+    commit(&dir);
+    let result = run(&dir, "HEAD~1", false);
+    assert!(result["omissions"]["target"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|o| o["file"] == "link.rs"));
+    assert!(!result.to_string().contains("secret"));
+    let result = run(&dir, "HEAD", true);
+    assert!(result["omissions"]["target"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|o| o["file"] == "link.rs"));
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,3 +1,4 @@
+pub mod analyze_changes;
 pub mod ensure_project_ready;
 pub mod find_callees;
 pub mod find_callers;

--- a/src/tools/orchestrator.rs
+++ b/src/tools/orchestrator.rs
@@ -755,11 +755,23 @@ pub async fn analyze_impact(params: AnalyzeImpactParams) -> anyhow::Result<Value
     let profile = load_project_meta(&canonical)
         .ok()
         .map(|meta| meta.repo_profile);
+    let seeds = resolve_impact_seeds(&params).await?;
+    impact_from_seeds(&params, &index, &canonical, &seeds, profile.as_ref(), true)
+}
+
+/// Shared weighted traversal for explicit targets and revision-local diff seeds.
+pub(crate) fn impact_from_seeds(
+    params: &AnalyzeImpactParams,
+    index: &crate::index::SymbolIndex,
+    canonical: &Path,
+    seeds: &[ImpactSeed],
+    profile: Option<&RepoProfile>,
+    record_session: bool,
+) -> anyhow::Result<Value> {
     let depth_limit = params.depth.unwrap_or(2).clamp(1, 3);
     let limit = params.limit.unwrap_or(8).clamp(1, 12);
     let query = params.query.as_deref().unwrap_or("");
     let scope_set = build_scope_set(params.scope.as_deref());
-    let seeds = resolve_impact_seeds(&params).await?;
     if seeds.is_empty() {
         return Err(anyhow::anyhow!(
             "analyze_impact could not resolve a seed symbol. Provide symbol_id, file_path, or a more specific query."
@@ -771,7 +783,7 @@ pub async fn analyze_impact(params: AnalyzeImpactParams) -> anyhow::Result<Value
     let mut frontier: Vec<(String, usize, i32, i32, String)> = Vec::new();
     let mut best_paths: HashMap<String, (i32, usize, i32)> = HashMap::new();
 
-    for seed in &seeds {
+    for seed in seeds {
         frontier.push((seed.id.clone(), 0, 120, 0, "seed".to_string()));
         best_paths.insert(seed.id.clone(), (120, 0, 0));
         impacted_files
@@ -804,10 +816,9 @@ pub async fn analyze_impact(params: AnalyzeImpactParams) -> anyhow::Result<Value
             continue;
         }
 
-        for neighbor in collect_impact_neighbors(&index, &symbol_id, &canonical, scope_set.as_ref())
-        {
+        for neighbor in collect_impact_neighbors(index, &symbol_id, canonical, scope_set.as_ref()) {
             let distance = depth + 1;
-            let score = impact_edge_score(distance, &neighbor, &canonical, profile.as_ref(), query);
+            let score = impact_edge_score(distance, &neighbor, canonical, profile, query);
             let next_path_score = path_score + score - (distance as i32 * 8);
             let next_path_priority = path_priority + neighbor.priority;
             let candidate_state = (next_path_score, distance, next_path_priority);
@@ -870,10 +881,12 @@ pub async fn analyze_impact(params: AnalyzeImpactParams) -> anyhow::Result<Value
             .then(a.distance.cmp(&b.distance))
             .then(a.name.cmp(&b.name))
     });
+    let total_impact_symbols = symbol_values.len();
     symbol_values.truncate(limit);
 
     let mut file_values: Vec<ImpactFile> = impacted_files.into_values().collect();
     file_values.sort_by(|a, b| b.score.cmp(&a.score).then(a.file.cmp(&b.file)));
+    let total_impact_files = file_values.len();
     file_values.truncate(limit);
 
     let steering = if symbol_values.is_empty() {
@@ -913,6 +926,11 @@ pub async fn analyze_impact(params: AnalyzeImpactParams) -> anyhow::Result<Value
             "file": seed.file,
         })).collect::<Vec<_>>(),
         "depth_limit": depth_limit,
+        "limit": limit,
+        "total_impact_symbols": total_impact_symbols,
+        "total_impact_files": total_impact_files,
+        "omitted_impact_symbols": total_impact_symbols.saturating_sub(symbol_values.len()),
+        "omitted_impact_files": total_impact_files.saturating_sub(file_values.len()),
         "impact_symbols": symbol_values.iter().map(|s| s.to_json()).collect::<Vec<_>>(),
         "impact_files": file_values.iter().map(|f| f.to_json()).collect::<Vec<_>>(),
         "edge_provenance_summary": build_edge_provenance_summary(&symbol_values, &file_values),
@@ -922,13 +940,17 @@ pub async fn analyze_impact(params: AnalyzeImpactParams) -> anyhow::Result<Value
             "Weighted graph traversal identified the most likely blast-radius targets."
         },
     });
+    if !record_session {
+        attach_steering(&mut response, steering);
+        return Ok(response);
+    }
     let impact_followup = response["impact_symbols"]
         .as_array()
         .and_then(|items| items.first())
-        .map(|top| expansion_followup_state(&canonical, top));
-    session::record_query(&canonical, query);
+        .map(|top| expansion_followup_state(canonical, top));
+    session::record_query(canonical, query);
     session::record_files(
-        &canonical,
+        canonical,
         response["impact_files"]
             .as_array()
             .into_iter()
@@ -936,7 +958,7 @@ pub async fn analyze_impact(params: AnalyzeImpactParams) -> anyhow::Result<Value
             .filter_map(|item| item["file"].as_str().map(ToOwned::to_owned)),
     );
     session::record_symbols(
-        &canonical,
+        canonical,
         response["impact_symbols"]
             .as_array()
             .into_iter()
@@ -2278,11 +2300,11 @@ fn impact_symbol_kind_bonus(kind: &str) -> i32 {
 }
 
 #[derive(Clone)]
-struct ImpactSeed {
-    id: String,
-    name: String,
-    kind: String,
-    file: String,
+pub(crate) struct ImpactSeed {
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) kind: String,
+    pub(crate) file: String,
 }
 
 #[derive(Clone, Copy)]
@@ -2576,7 +2598,7 @@ fn matches_scope(path: &Path, project_path: &Path, scope_set: Option<&GlobSet>) 
 }
 
 fn collect_impact_neighbors(
-    index: &Arc<crate::index::SymbolIndex>,
+    index: &crate::index::SymbolIndex,
     symbol_id: &str,
     project_path: &Path,
     scope_set: Option<&GlobSet>,

--- a/tests/rmcp_protocol.rs
+++ b/tests/rmcp_protocol.rs
@@ -62,6 +62,22 @@ fn tools_list_result(protocol_version: &str) -> Value {
 }
 
 #[test]
+fn analyze_changes_is_public_with_required_revision_schema() {
+    let result = tools_list_result("2026-07-28");
+    let tool = result["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|tool| tool["name"] == "analyze_changes")
+        .expect("public analyze_changes tool");
+    let required = tool["inputSchema"]["required"].as_array().unwrap();
+    assert!(required.contains(&json!("project")));
+    assert!(required.contains(&json!("base_ref")));
+    assert!(!required.contains(&json!("include_working_tree")));
+    assert_eq!(tool["annotations"]["readOnlyHint"], true);
+}
+
+#[test]
 fn legacy_tools_list_omits_2026_result_fields() {
     let result = tools_list_result("2025-11-25");
 


### PR DESCRIPTION
## Summary
- Add public `analyze_changes` MCP tool and `pitlane analyze-changes` CLI command.
- Map diff hunks to revision-qualified symbols using separate in-memory base and target indexes; retain deleted-symbol callers from the base revision.
- Reuse weighted impact traversal, expose heuristic/uncertain evidence and test candidates, and report exclusions, omissions, and limits.
- Cover committed and working-tree changes, untracked files, renames, subtrees, exclusions, parse errors, symlinks, and bounded results.

## Semantics and limitations
- Compare base directly against HEAD by default, or files on disk with `include_working_tree=true` (including non-ignored untracked files).
- Renames are represented as deletion/addition; graph edges and test classification remain heuristic.
- No checkout, cached-index mutation, or embeddings required.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- CLI smoke test against this repository.

Closes #81