### PR TITLE
feat: index revision tracking, change feed, and optional watching on startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Default public tier:
 - `trace_path`
 - `analyze_impact`
 - `analyze_changes`
+- `get_index_changes`
 - `get_index_stats`
 - `search_content`
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -21,6 +21,7 @@ Notes:
 - Does not block on embeddings
 - Accepts `exclude`, `force`, and `max_files`
 - Accepts `poll_interval_ms` and `timeout_secs` for compatibility, but they are currently ignored
+- Starts a background watcher by default so edits update the index incrementally; pass `"watch": false` to opt out. The response reports the watcher status in `watching`.
 
 ### `investigate`
 
@@ -119,6 +120,16 @@ Return lightweight repo orientation data such as language and symbol counts.
 ```
 
 Use this before broader exploration when you want orientation, not structure.
+
+### `get_index_changes`
+
+List symbols the index recorded as changed since a revision, newest first.
+
+```json
+{ "project": "/your/project", "since_revision": 4, "limit": 20 }
+```
+
+The index revision is a monotonically increasing counter persisted with the index; every navigation response includes the current value as `index_revision`. Revisions are assigned by every persisted content change: fresh indexing, watcher batch flushes, and full resyncs. Poll `get_index_changes` with the revision you last observed to learn exactly which symbols were added, removed, or touched without re-reading files. A revision becomes visible once the index flush lands — pending embedding work never delays it. The change log is bounded (most recent 50 revisions, per-list caps); responses carry `complete` so you know when the log was trimmed and a re-index is the safe re-baseline.
 
 ### `search_content`
 

--- a/src/bin/pitlane.rs
+++ b/src/bin/pitlane.rs
@@ -166,6 +166,17 @@ enum Command {
         /// Path to the indexed project
         project: String,
     },
+    /// List symbols changed since an index revision
+    Changes {
+        /// Path to the indexed project
+        project: String,
+        /// Return revisions strictly newer than this revision (default: current)
+        #[arg(long)]
+        since: Option<u64>,
+        /// Maximum number of revisions returned, newest first (default: 20)
+        #[arg(long)]
+        limit: Option<usize>,
+    },
     /// Trace the strongest graph-backed path for a query
     TracePath {
         /// Path to the indexed project
@@ -509,6 +520,19 @@ async fn run_command(command: Command) -> anyhow::Result<serde_json::Value> {
         Command::Stats { project } => {
             let params = tools::get_index_stats::GetIndexStatsParams { project };
             tools::get_index_stats::get_index_stats(params).await?
+        }
+
+        Command::Changes {
+            project,
+            since,
+            limit,
+        } => {
+            let params = tools::index_changes::GetIndexChangesParams {
+                project,
+                since_revision: since,
+                limit,
+            };
+            tools::index_changes::get_index_changes(params).await?
         }
 
         Command::TracePath {

--- a/src/index/format.rs
+++ b/src/index/format.rs
@@ -38,10 +38,82 @@ pub struct IndexMeta {
     /// initial indexing.
     #[serde(default)]
     pub effective_excludes: Vec<String>,
+    /// Monotonic index revision: bumped on every persisted content change
+    /// (fresh index, watcher batch flush, full resync). Zero means the index
+    /// predates revision tracking; the next write assigns revision 1.
+    #[serde(default)]
+    pub revision: u64,
+    /// Bounded per-revision change log backing `get_index_changes` (issue #82).
+    /// Oldest entries are dropped as new revisions are recorded.
+    #[serde(default)]
+    pub change_log: Vec<RevisionChange>,
     pub repo_profile: RepoProfile,
 }
 
+/// Symbol-level diff recorded for one index revision.
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
+pub struct RevisionChange {
+    pub revision: u64,
+    /// Symbol IDs present in this revision but not the previous one.
+    #[serde(default)]
+    pub added: Vec<String>,
+    /// Symbol IDs present in the previous revision but not this one.
+    #[serde(default)]
+    pub removed: Vec<String>,
+    /// Symbol IDs present in both revisions whose defining file was reindexed
+    /// (content may or may not have changed; IDs are file/name/kind based).
+    #[serde(default)]
+    pub modified: Vec<String>,
+    /// True if any list was capped and the entry is not exhaustive.
+    #[serde(default)]
+    pub truncated: bool,
+}
+
+/// Per-list cap for recorded change entries; keeps meta.json bounded for
+/// large refactors while preserving the most recent revisions.
+const CHANGE_LOG_MAX_REVISIONS: usize = 50;
+const CHANGE_LIST_CAP: usize = 200;
+
+impl RevisionChange {
+    fn from_diff(added: Vec<String>, removed: Vec<String>, modified: Vec<String>) -> Self {
+        let truncated = added.len() > CHANGE_LIST_CAP
+            || removed.len() > CHANGE_LIST_CAP
+            || modified.len() > CHANGE_LIST_CAP;
+        let cap = |mut v: Vec<String>| {
+            if v.len() > CHANGE_LIST_CAP {
+                v.truncate(CHANGE_LIST_CAP);
+            }
+            v
+        };
+        Self {
+            revision: 0,
+            added: cap(added),
+            removed: cap(removed),
+            modified: cap(modified),
+            truncated,
+        }
+    }
+}
+
 impl IndexMeta {
+    /// Assigns `revision = current + 1`, records the symbol diff as the
+    /// change-log entry for that revision, and trims the log to its bound.
+    pub fn record_change(
+        &mut self,
+        added: Vec<String>,
+        removed: Vec<String>,
+        modified: Vec<String>,
+    ) {
+        self.revision = self.revision.wrapping_add(1);
+        let mut change = RevisionChange::from_diff(added, removed, modified);
+        change.revision = self.revision;
+        self.change_log.push(change);
+        if self.change_log.len() > CHANGE_LOG_MAX_REVISIONS {
+            let excess = self.change_log.len() - CHANGE_LOG_MAX_REVISIONS;
+            self.change_log.drain(0..excess);
+        }
+    }
+
     pub fn new(project_path: &Path) -> Self {
         Self {
             project_path: project_path.display().to_string(),
@@ -51,6 +123,8 @@ impl IndexMeta {
             dir_mtimes: HashMap::new(),
             source_file_count: 0,
             effective_excludes: Vec::new(),
+            revision: 0,
+            change_log: Vec::new(),
             repo_profile: RepoProfile::default(),
         }
     }

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -15,6 +15,10 @@ pub struct SymbolIndex {
     pub by_kind: HashMap<SymbolKind, Vec<SymbolId>>,
     pub by_language: HashMap<Language, Vec<SymbolId>>,
     pub graph: NavigationGraph,
+    /// Index revision loaded from `IndexMeta.revision` and bumped by the
+    /// watcher on every flush. Not part of the on-disk index serialization.
+    /// Not serialized; navigation responses surface this as `index_revision`.
+    pub revision: u64,
     /// Intern table: deduplicated Arc<PathBuf> per unique file path.
     /// Not serialized; rebuilt by rebuild_secondary_indexes after loading.
     file_interner: HashMap<PathBuf, Arc<PathBuf>>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,8 @@ pub struct EnsureProjectReadyRequest {
     pub poll_interval_ms: Option<u64>,
     /// Accepted for compatibility but currently ignored; ensure_project_ready no longer waits for embeddings.
     pub timeout_secs: Option<u64>,
+    /// Start a background watcher so file edits update the index incrementally (default: true). Set false to index once and exit.
+    pub watch: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
@@ -372,6 +374,16 @@ pub struct GetIndexStatsRequest {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct GetIndexChangesRequest {
+    /// Project path previously indexed
+    pub project: String,
+    /// Return revisions strictly newer than this index revision
+    pub since_revision: Option<u64>,
+    /// Maximum number of revisions returned, newest first (default: 20)
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct GetUsageStatsRequest {
     /// Filter to a single project path (default: return all projects + global total)
     pub project: Option<String>,
@@ -396,6 +408,7 @@ const DEFAULT_PUBLIC_TOOL_NAMES: &[&str] = &[
     "trace_path",
     "analyze_impact",
     "analyze_changes",
+    "get_index_changes",
     "get_index_stats",
     "search_content",
 ];
@@ -572,6 +585,8 @@ impl PitlaneMcp {
             progress_token: meta.get_progress_token(),
             peer: Some(peer),
             embed_config: self.embed_config.clone(),
+            watch: req.watch,
+            watcher_registry: Some(self.watcher_registry.clone()),
         };
         match tools::ensure_project_ready::ensure_project_ready(params).await {
             Ok(v) => value_to_text(v),
@@ -1089,6 +1104,31 @@ impl PitlaneMcp {
             project: req.project,
         };
         match tools::get_index_stats::get_index_stats(params).await {
+            Ok(v) => value_to_text(v),
+            Err(e) => err_to_text(e),
+        }
+    }
+
+    #[tool(
+        description = "List symbols changed since an index revision. Poll after edits to learn which symbols the index picked up without re-reading files.",
+        meta = tool_meta("freshness changed symbols revision feed delta index"),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn get_index_changes(
+        &self,
+        Parameters(req): Parameters<GetIndexChangesRequest>,
+    ) -> String {
+        let params = tools::index_changes::GetIndexChangesParams {
+            project: req.project,
+            since_revision: req.since_revision,
+            limit: req.limit,
+        };
+        match tools::index_changes::get_index_changes(params).await {
             Ok(v) => value_to_text(v),
             Err(e) => err_to_text(e),
         }

--- a/src/tools/ensure_project_ready.rs
+++ b/src/tools/ensure_project_ready.rs
@@ -5,6 +5,7 @@ use serde_json::{json, Value};
 
 use crate::embed::EmbedConfig;
 use crate::tools::index_project::{index_project, IndexProjectParams};
+use crate::tools::watch_project::{watch_project, WatchProjectParams, WatcherRegistry};
 
 pub struct EnsureProjectReadyParams {
     pub path: String,
@@ -16,6 +17,11 @@ pub struct EnsureProjectReadyParams {
     pub progress_token: Option<ProgressToken>,
     pub peer: Option<Peer<RoleServer>>,
     pub embed_config: Option<Arc<EmbedConfig>>,
+    /// Start a background watcher after indexing so edits are picked up
+    /// incrementally (issue #82). Defaults to true when a watcher registry is
+    /// available (MCP server); the CLI passes no registry and skips watching.
+    pub watch: Option<bool>,
+    pub watcher_registry: Option<Arc<WatcherRegistry>>,
 }
 
 pub async fn ensure_project_ready(params: EnsureProjectReadyParams) -> anyhow::Result<Value> {
@@ -32,6 +38,36 @@ pub async fn ensure_project_ready(params: EnsureProjectReadyParams) -> anyhow::R
 
     let embeddings_status = indexed["embeddings"].as_str().unwrap_or("disabled");
 
+    // Optional watching (issue #82): after a successful index, keep it fresh
+    // incrementally. Never fails startup if the watcher cannot start.
+    let watching = if params.watch.unwrap_or(true) {
+        match &params.watcher_registry {
+            Some(registry) => match watch_project(
+                WatchProjectParams {
+                    project: params.path.clone(),
+                    stop: Some(false),
+                    status_only: Some(false),
+                    embed_config: params.embed_config.clone(),
+                },
+                registry,
+            )
+            .await
+            {
+                Ok(status) => status,
+                Err(err) => json!({
+                    "status": "failed",
+                    "message": format!("watcher could not start; index remains valid but will not self-update: {err}"),
+                }),
+            },
+            None => json!({
+                "status": "unavailable",
+                "message": "Watcher registry not available in this context (CLI mode). Use watch_project on the MCP server for live updates.",
+            }),
+        }
+    } else {
+        json!({ "status": "disabled", "message": "watch=false; call watch_project to enable live index updates." })
+    };
+
     let mut ignored_parameters = Vec::new();
     if params.poll_interval_ms.is_some() {
         ignored_parameters.push("poll_interval_ms");
@@ -44,6 +80,7 @@ pub async fn ensure_project_ready(params: EnsureProjectReadyParams) -> anyhow::R
         "status": "ready",
         "index": indexed,
         "waited_for_embeddings": false,
+        "watching": watching,
         "embeddings": {
             "status": embeddings_status,
             "message": if embeddings_status == "running" {
@@ -94,6 +131,8 @@ mod tests {
             progress_token: None,
             peer: None,
             embed_config: None,
+            watch: Some(false),
+            watcher_registry: None,
         })
         .await
         .unwrap();
@@ -127,6 +166,8 @@ mod tests {
             progress_token: None,
             peer: None,
             embed_config: None,
+            watch: Some(false),
+            watcher_registry: None,
         })
         .await
         .unwrap();
@@ -134,5 +175,54 @@ mod tests {
         let ignored = result["ignored_parameters"].as_array().unwrap();
         assert_eq!(ignored.len(), 2);
         assert!(result["compatibility"]["note"].is_string());
+    }
+
+    #[tokio::test]
+    async fn test_ensure_project_ready_watch_false_reports_disabled() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("lib.rs"), "pub fn hello() {}\n").unwrap();
+
+        let result = ensure_project_ready(EnsureProjectReadyParams {
+            path: dir.path().to_string_lossy().to_string(),
+            exclude: None,
+            force: Some(true),
+            max_files: None,
+            poll_interval_ms: None,
+            timeout_secs: None,
+            progress_token: None,
+            peer: None,
+            embed_config: None,
+            watch: Some(false),
+            watcher_registry: None,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(result["watching"]["status"], json!("disabled"));
+    }
+
+    #[tokio::test]
+    async fn test_ensure_project_ready_without_registry_reports_unavailable() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("lib.rs"), "pub fn hello() {}\n").unwrap();
+
+        let result = ensure_project_ready(EnsureProjectReadyParams {
+            path: dir.path().to_string_lossy().to_string(),
+            exclude: None,
+            force: Some(true),
+            max_files: None,
+            poll_interval_ms: None,
+            timeout_secs: None,
+            progress_token: None,
+            peer: None,
+            embed_config: None,
+            watch: Some(true),
+            watcher_registry: None,
+        })
+        .await
+        .unwrap();
+
+        // CLI-style invocation: no registry, watching degrades gracefully.
+        assert_eq!(result["watching"]["status"], json!("unavailable"));
     }
 }

--- a/src/tools/find_callees.rs
+++ b/src/tools/find_callees.rs
@@ -83,6 +83,7 @@ pub async fn find_callees(params: FindCalleesParams) -> anyhow::Result<Value> {
         )
     };
     attach_steering(&mut response, steering);
+    response["index_revision"] = json!(index.revision);
     Ok(response)
 }
 

--- a/src/tools/find_callers.rs
+++ b/src/tools/find_callers.rs
@@ -112,6 +112,7 @@ pub async fn find_callers(params: FindCallersParams) -> anyhow::Result<Value> {
         )
     };
     attach_steering(&mut response, steering);
+    response["index_revision"] = json!(index.revision);
     Ok(response)
 }
 

--- a/src/tools/get_file_outline.rs
+++ b/src/tools/get_file_outline.rs
@@ -77,6 +77,7 @@ pub async fn get_file_outline(params: GetFileOutlineParams) -> anyhow::Result<Va
     response["content_seen"] = json!(observation.content_seen);
     response["target_seen"] = json!(observation.target_seen);
     response["content_changed"] = json!(observation.changed_since_last_read);
+    response["index_revision"] = json!(index.revision);
 
     Ok(response)
 }

--- a/src/tools/get_symbol.rs
+++ b/src/tools/get_symbol.rs
@@ -132,6 +132,7 @@ pub async fn get_symbol(params: GetSymbolParams) -> anyhow::Result<Value> {
             &sym.id,
             Some(sym.file.as_ref()),
         );
+        response["index_revision"] = json!(index.revision);
         return Ok(response);
     }
 
@@ -209,6 +210,7 @@ pub async fn get_symbol(params: GetSymbolParams) -> anyhow::Result<Value> {
         &sym.id,
         Some(sym.file.as_ref()),
     );
+    response["index_revision"] = json!(index.revision);
 
     Ok(response)
 }

--- a/src/tools/index_changes.rs
+++ b/src/tools/index_changes.rs
@@ -1,0 +1,204 @@
+use serde_json::{json, Value};
+
+use crate::index::format::{load_project_meta, RevisionChange};
+use crate::path_policy::resolve_project_path;
+use crate::tools::index_project::load_project_index;
+
+pub struct GetIndexChangesParams {
+    pub project: String,
+    /// Return only revisions strictly greater than this value.
+    /// Defaults to the current revision (i.e. "no changes").
+    pub since_revision: Option<u64>,
+    /// Maximum number of revisions returned, newest first (default: 20).
+    pub limit: Option<usize>,
+}
+
+/// Feed of symbols changed since an index revision (issue #82).
+///
+/// Revisions are assigned by every persisted content change (fresh indexing,
+/// watcher batch flush, full resync). A revision is visible to this tool once
+/// the index flush lands; background embedding work does not delay it.
+pub async fn get_index_changes(params: GetIndexChangesParams) -> anyhow::Result<Value> {
+    let index = load_project_index(&params.project)?;
+    let canonical = resolve_project_path(&params.project)?;
+    let meta = load_project_meta(&canonical)?;
+    let current = meta.revision.max(index.revision);
+
+    let since = params.since_revision.unwrap_or(current);
+    let limit = params.limit.unwrap_or(20).max(1);
+
+    // Newest first. Revisions the client already knows about are excluded.
+    let mut entries: Vec<&RevisionChange> = meta
+        .change_log
+        .iter()
+        .filter(|change| change.revision > since)
+        .collect();
+    entries.sort_by(|a, b| b.revision.cmp(&a.revision));
+
+    let earliest_logged = meta.change_log.iter().map(|c| c.revision).min();
+    // The feed is complete when every revision between `since + 1` and
+    // `current` has a log entry; otherwise the log was trimmed.
+    let complete = match earliest_logged {
+        Some(earliest) => since + 1 >= earliest,
+        // No entries at all: complete iff there is nothing to report.
+        None => since >= current,
+    };
+
+    // Aggregate distinct changed symbol IDs across the returned revisions.
+    let mut changed_symbols: Vec<String> = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for change in &entries {
+        for id in change
+            .added
+            .iter()
+            .chain(change.removed.iter())
+            .chain(change.modified.iter())
+        {
+            if seen.insert(id.clone()) {
+                changed_symbols.push(id.clone());
+            }
+        }
+    }
+
+    let changes: Vec<Value> = entries
+        .iter()
+        .take(limit)
+        .map(|change| {
+            json!({
+                "revision": change.revision,
+                "added": change.added,
+                "removed": change.removed,
+                "modified": change.modified,
+                "truncated": change.truncated,
+            })
+        })
+        .collect();
+
+    let omitted_revisions = entries.len().saturating_sub(limit);
+
+    Ok(json!({
+        "project": canonical.display().to_string(),
+        "current_revision": current,
+        "since_revision": since,
+        "up_to_date": since >= current,
+        "complete": complete,
+        "changed_symbol_count": changed_symbols.len(),
+        "changed_symbols": changed_symbols,
+        "revisions": changes,
+        "omitted_revisions": omitted_revisions,
+        "limits": { "max_revisions": limit },
+        "note": if since >= current {
+            "Index is at or ahead of the requested revision; no changes to report."
+        } else if !complete {
+            "The change log was trimmed; some revisions between since_revision and current_revision are no longer available. Re-index to re-baseline."
+        } else {
+            "Revisions become visible once the index flush completes; pending embedding work does not affect them."
+        },
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::index::format::IndexMeta;
+    use crate::tools::index_project::{index_project, IndexProjectParams};
+    use tempfile::TempDir;
+
+    async fn index_dir(dir: &TempDir) -> String {
+        index_project(IndexProjectParams {
+            path: dir.path().to_string_lossy().to_string(),
+            exclude: None,
+            force: Some(true),
+            max_files: None,
+            progress_token: None,
+            peer: None,
+            embed_config: None,
+        })
+        .await
+        .unwrap();
+        dir.path().to_string_lossy().to_string()
+    }
+
+    #[tokio::test]
+    async fn test_fresh_index_reports_no_changes_at_current_revision() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("lib.rs"), b"pub fn hello() {}\n").unwrap();
+        let project = index_dir(&dir).await;
+
+        let result = get_index_changes(GetIndexChangesParams {
+            project,
+            since_revision: None,
+            limit: None,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(result["current_revision"], json!(1));
+        assert_eq!(result["up_to_date"], json!(true));
+        assert_eq!(result["revisions"], json!([]));
+    }
+
+    #[tokio::test]
+    async fn test_revisions_from_zero_include_baseline() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("lib.rs"), b"pub fn hello() {}\n").unwrap();
+        let project = index_dir(&dir).await;
+
+        let result = get_index_changes(GetIndexChangesParams {
+            project,
+            since_revision: Some(0),
+            limit: None,
+        })
+        .await
+        .unwrap();
+
+        // Revision 1 is the baseline index; since=0 sees it as one change.
+        assert_eq!(result["current_revision"], json!(1));
+        assert_eq!(result["complete"], json!(true));
+        let revisions = result["revisions"].as_array().unwrap();
+        assert_eq!(revisions.len(), 1);
+        assert_eq!(revisions[0]["revision"], json!(1));
+    }
+
+    #[test]
+    fn test_record_change_assigns_monotonic_revisions_and_trims() {
+        let mut meta = IndexMeta::new(std::path::Path::new("/tmp/x"));
+        assert_eq!(meta.revision, 0);
+        for i in 0..60 {
+            meta.record_change(vec![format!("sym{i}")], Vec::new(), Vec::new());
+        }
+        assert_eq!(meta.revision, 60);
+        assert_eq!(meta.change_log.len(), 50);
+        assert_eq!(meta.change_log[0].revision, 11, "oldest entries trimmed");
+        assert_eq!(meta.change_log[49].revision, 60);
+    }
+
+    #[test]
+    fn test_record_change_caps_lists_and_flags_truncation() {
+        let mut meta = IndexMeta::new(std::path::Path::new("/tmp/x"));
+        let big: Vec<String> = (0..300).map(|i| format!("sym{i}")).collect();
+        meta.record_change(big.clone(), big.clone(), big);
+        let entry = &meta.change_log[0];
+        assert!(entry.truncated);
+        assert_eq!(entry.added.len(), 200);
+        assert_eq!(entry.removed.len(), 200);
+        assert_eq!(entry.modified.len(), 200);
+    }
+
+    #[test]
+    fn test_meta_without_change_log_loads_with_defaults() {
+        // A meta.json written before revision tracking must deserialize with
+        // revision 0 and an empty log (serde defaults).
+        let json = r#"{
+            "project_path": "/tmp/x",
+            "version": 5,
+            "indexed_at": "0",
+            "file_mtimes": {},
+            "source_file_count": 0,
+            "repo_profile": {"archetype": "library", "file_roles": {}, "role_counts": {}, "entrypoints": []}
+        }"#;
+        let meta: IndexMeta = serde_json::from_str(json).unwrap();
+        assert_eq!(meta.revision, 0);
+        assert!(meta.change_log.is_empty());
+    }
+}

--- a/src/tools/index_changes.rs
+++ b/src/tools/index_changes.rs
@@ -33,7 +33,7 @@ pub async fn get_index_changes(params: GetIndexChangesParams) -> anyhow::Result<
         .iter()
         .filter(|change| change.revision > since)
         .collect();
-    entries.sort_by(|a, b| b.revision.cmp(&a.revision));
+    entries.sort_by_key(|change| std::cmp::Reverse(change.revision));
 
     let earliest_logged = meta.change_log.iter().map(|c| c.revision).min();
     // The feed is complete when every revision between `since + 1` and

--- a/src/tools/index_project.rs
+++ b/src/tools/index_project.rs
@@ -277,7 +277,7 @@ async fn do_index_project(
 
     let canonical_clone = canonical.clone();
     let exclude_for_indexing = exclude.clone();
-    let (index, file_count) = tokio::task::spawn_blocking(move || {
+    let (mut index, file_count) = tokio::task::spawn_blocking(move || {
         let cb = make_cb();
         indexer.index_project_with_progress(
             &canonical_clone,
@@ -318,6 +318,14 @@ async fn do_index_project(
     // Persist the effective exclusions so watcher updates and full resyncs
     // apply the same policy (issue #74).
     meta.effective_excludes = exclude.clone();
+    // Fresh indexing is a content change (issue #82): carry over the previous
+    // revision and let record_change assign the next one. The baseline is
+    // recorded as a change whose `added` list is every indexed symbol (capped
+    // per RevisionChange).
+    meta.revision = load_meta(&meta_path).map(|prev| prev.revision).unwrap_or(0);
+    let all_ids: Vec<String> = index.symbols.keys().cloned().collect();
+    meta.record_change(all_ids, Vec::new(), Vec::new());
+    index.revision = meta.revision;
     save_meta(&meta, &meta_path)?;
 
     // Build the BM25 index. Invalidate any stale cached reader first so the
@@ -618,6 +626,10 @@ pub fn load_project_index(project: &str) -> anyhow::Result<Arc<SymbolIndex>> {
     }
 
     let mut index = crate::index::format::load_index(&index_path)?;
+    // Surface the persisted revision (issue #82); default 0 for pre-revision indexes.
+    index.revision = crate::index::format::load_meta(&idx_dir.join("meta.json"))
+        .map(|meta| meta.revision)
+        .unwrap_or(0);
     let before = index.symbol_count();
     index.symbols.retain(|_, sym| {
         let Ok(Some(canonical_file)) = canonical_regular_file(sym.file.as_ref()) else {

--- a/src/tools/investigate.rs
+++ b/src/tools/investigate.rs
@@ -663,7 +663,7 @@ pub async fn investigate(params: InvestigateParams) -> anyhow::Result<Value> {
 
     session::record_query(&canonical, &query);
 
-    let response = json!({
+    let mut response = json!({
         "query": query,
         "answer": answer,
         "symbols_read": symbols_seen.len(),
@@ -678,6 +678,7 @@ pub async fn investigate(params: InvestigateParams) -> anyhow::Result<Value> {
         },
         "repeated": false,
     });
+    response["index_revision"] = json!(index.revision);
     session::store_investigate_cache(&canonical, &cache_key, response.clone());
 
     Ok(response)

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -9,6 +9,7 @@ pub mod get_lines;
 pub mod get_project_outline;
 pub mod get_symbol;
 pub mod get_usage_stats;
+pub mod index_changes;
 pub mod index_project;
 pub mod investigate;
 pub mod orchestrator;

--- a/src/tools/orchestrator.rs
+++ b/src/tools/orchestrator.rs
@@ -228,6 +228,9 @@ pub async fn locate_code(params: LocateCodeParams) -> anyhow::Result<Value> {
             Some((id, file))
         }),
     );
+    response["index_revision"] = json!(load_project_index(&params.project)
+        .map(|index| index.revision)
+        .unwrap_or(0));
     Ok(response)
 }
 
@@ -613,7 +616,8 @@ pub async fn trace_path(params: TracePathParams) -> anyhow::Result<Value> {
         }
     }
 
-    let response = trace_execution_path(TraceExecutionPathParams {
+    let project_str = params.project.clone();
+    let mut response = trace_execution_path(TraceExecutionPathParams {
         project: params.project,
         query: query.clone(),
         source: source_hint.clone(),
@@ -738,6 +742,9 @@ pub async fn trace_path(params: TracePathParams) -> anyhow::Result<Value> {
             .iter()
             .filter_map(|item| item["file"].as_str().map(ToOwned::to_owned)),
     );
+    response["index_revision"] = json!(load_project_index(&project_str)
+        .map(|index| index.revision)
+        .unwrap_or(0));
     session::record_symbols(
         &canonical,
         compact_symbols.iter().filter_map(|item| {
@@ -756,7 +763,10 @@ pub async fn analyze_impact(params: AnalyzeImpactParams) -> anyhow::Result<Value
         .ok()
         .map(|meta| meta.repo_profile);
     let seeds = resolve_impact_seeds(&params).await?;
-    impact_from_seeds(&params, &index, &canonical, &seeds, profile.as_ref(), true)
+    let mut response =
+        impact_from_seeds(&params, &index, &canonical, &seeds, profile.as_ref(), true)?;
+    response["index_revision"] = json!(index.revision);
+    Ok(response)
 }
 
 /// Shared weighted traversal for explicit targets and revision-local diff seeds.
@@ -1120,6 +1130,9 @@ pub async fn navigate_code(params: NavigateCodeParams) -> anyhow::Result<Value> 
         }
     }
     apply_navigation_followup(&mut response);
+    response["index_revision"] = json!(load_project_index(&params.project)
+        .map(|index| index.revision)
+        .unwrap_or(0));
     Ok(response)
 }
 

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -254,6 +254,32 @@ async fn full_resync(
             let _ = crate::index::bm25::mark_stale(&tantivy_dir);
         }
         crate::index::bm25::invalidate(root);
+
+        // Record the resync as a new revision with a symbol-level diff
+        // against the pre-resync symbol set (issue #82).
+        let old_ids: HashSet<&str> = old_removed_ids.iter().map(|s| s.as_str()).collect();
+        let mut added = Vec::new();
+        let mut modified = Vec::new();
+        for id in idx.symbols.keys() {
+            if old_ids.contains(id.as_str()) {
+                modified.push(id.clone());
+            } else {
+                added.push(id.clone());
+            }
+        }
+        let removed: Vec<String> = old_removed_ids
+            .iter()
+            .filter(|id| !idx.symbols.contains_key(id.as_str()))
+            .cloned()
+            .collect();
+        let mut meta = load_meta(meta_path).unwrap_or_else(|_| IndexMeta::new(root));
+        meta.record_change(added, removed, modified);
+        idx.revision = meta.revision;
+        drop(idx);
+
+        if let Err(e) = save_meta(&meta, meta_path) {
+            eprintln!("pitlane-mcp: failed to flush meta to disk: {}", e);
+        }
     }
 
     if let Some(cfg) = &embed_config {
@@ -341,6 +367,38 @@ async fn reindex_batch(
             let _ = crate::index::bm25::mark_stale(&tantivy_dir);
         }
         crate::index::bm25::invalidate(root);
+
+        // Record the flush as a new revision (issue #82): added = symbols in
+        // the affected files that were not there before, removed = prior
+        // symbols no longer present, modified = surviving symbols in those
+        // files (IDs are file/name/kind based, so a content edit usually
+        // keeps the ID).
+        let removed_set: HashSet<&str> = removed_ids.iter().map(|s| s.as_str()).collect();
+        let mut added = Vec::new();
+        let mut modified = Vec::new();
+        for path in &accepted {
+            if let Some(ids) = idx.by_file.get(path) {
+                for id in ids {
+                    if removed_set.contains(id.as_str()) {
+                        modified.push(id.clone());
+                    } else {
+                        added.push(id.clone());
+                    }
+                }
+            }
+        }
+        let removed: Vec<String> = removed_ids
+            .iter()
+            .filter(|id| !idx.symbols.contains_key(id.as_str()))
+            .cloned()
+            .collect();
+
+        let mut meta = load_meta(meta_path).unwrap_or_else(|_| IndexMeta::new(root));
+        meta.record_change(added, removed, modified);
+        idx.revision = meta.revision;
+        if let Err(e) = save_meta(&meta, meta_path) {
+            eprintln!("pitlane-mcp: failed to flush meta to disk: {}", e);
+        }
     }
     // write lock released — safe to re-acquire index.read() below
 
@@ -401,6 +459,7 @@ async fn reindex_batch(
 mod tests {
     use super::*;
     use crate::indexer::registry;
+    use serde_json::json;
     use std::sync::atomic::AtomicBool;
     use tempfile::TempDir;
 
@@ -816,5 +875,128 @@ mod tests {
         let names = symbol_names(&index).await;
         assert!(names.iter().any(|n| n == "kept"));
         assert!(!names.iter().any(|n| n == "vendor_new"), "names={names:?}");
+    }
+    /// A watcher batch flush records a new revision with a symbol-level diff
+    /// in meta, and the in-memory index revision advances with it (issue #82).
+    #[tokio::test]
+    async fn test_batch_flush_records_revision_and_change_log() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("lib.rs");
+        std::fs::write(&file, b"fn old_fn() {}").unwrap();
+
+        let indexer = Arc::new(Indexer::new(registry::build_default_registry()));
+        let (idx, _) = indexer.index_project(dir.path(), &[]).unwrap();
+        let index = Arc::new(RwLock::new(idx));
+
+        // Baseline meta at revision 1.
+        let meta_path = dir.path().join("meta.json");
+        let mut meta = IndexMeta::new(dir.path());
+        meta.record_change(
+            index.read().await.symbols.keys().cloned().collect(),
+            Vec::new(),
+            Vec::new(),
+        );
+        save_meta(&meta, &meta_path).unwrap();
+
+        // Edit + flush through the debounce loop.
+        let (tx, rx) = mpsc::channel(16);
+        let handle = spawn_loop(rx, &dir, indexer, index.clone());
+        std::fs::write(&file, b"fn new_fn() {}").unwrap();
+        tx.send(file).await.unwrap();
+        drop(tx);
+        handle.await.unwrap();
+
+        let meta = load_meta(&meta_path).unwrap();
+        assert_eq!(meta.revision, 2, "flush should assign revision 2");
+        let entry = meta.change_log.last().unwrap();
+        assert_eq!(entry.revision, 2);
+        assert!(
+            entry.added.iter().any(|id| id.contains("new_fn")),
+            "added={:?}",
+            entry.added
+        );
+        assert!(
+            entry.removed.iter().any(|id| id.contains("old_fn")),
+            "removed={:?}",
+            entry.removed
+        );
+
+        // In-memory index revision advanced so navigation responses see it.
+        let idx = index.read().await;
+        assert_eq!(idx.revision, 2);
+        assert!(!idx.symbols.values().any(|s| s.name == "old_fn"));
+        assert!(idx.symbols.values().any(|s| s.name == "new_fn"));
+    }
+    /// End-to-end issue #82: after a watcher flush, get_index_changes reports
+    /// the new revision with the changed symbols.
+    #[tokio::test]
+    async fn test_get_index_changes_surfaces_watcher_flush() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("lib.rs");
+        std::fs::write(&file, b"fn old_fn() {}").unwrap();
+
+        // Index through the real tool so the index lands in the global store
+        // where get_index_changes (and other tools) will read it.
+        crate::tools::index_project::index_project(
+            crate::tools::index_project::IndexProjectParams {
+                path: dir.path().to_string_lossy().to_string(),
+                exclude: None,
+                force: Some(true),
+                max_files: None,
+                progress_token: None,
+                peer: None,
+                embed_config: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let canonical =
+            crate::path_policy::resolve_project_path(&dir.path().to_string_lossy()).unwrap();
+        let idx_dir = index_dir(&canonical).unwrap();
+        let (idx, _) = Indexer::new(registry::build_default_registry())
+            .index_project(dir.path(), &[])
+            .unwrap();
+        let index = Arc::new(RwLock::new(idx));
+
+        // Flush through the real on-disk index/meta paths.
+        let root = dir.path().to_path_buf();
+        let indexer2 = Arc::new(Indexer::new(registry::build_default_registry()));
+        let (tx, rx) = mpsc::channel(16);
+        let handle = tokio::spawn(run_debounce_loop(
+            rx,
+            root,
+            indexer2,
+            index.clone(),
+            TEST_DEBOUNCE,
+            idx_dir.join("index.bin"),
+            idx_dir.join("meta.json"),
+            None,
+            Arc::new(AtomicBool::new(false)),
+        ));
+        std::fs::write(&file, b"fn new_fn() {}").unwrap();
+        tx.send(file).await.unwrap();
+        drop(tx);
+        handle.await.unwrap();
+
+        let changes = crate::tools::index_changes::get_index_changes(
+            crate::tools::index_changes::GetIndexChangesParams {
+                project: dir.path().to_string_lossy().to_string(),
+                since_revision: Some(0),
+                limit: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(changes["current_revision"], json!(2));
+        assert_eq!(changes["complete"], json!(true));
+        let symbols = changes["changed_symbols"].as_array().unwrap();
+        assert!(
+            symbols
+                .iter()
+                .any(|id| id.as_str().is_some_and(|s| s.contains("new_fn"))),
+            "changed_symbols={symbols:?}"
+        );
     }
 }

--- a/tests/rmcp_protocol.rs
+++ b/tests/rmcp_protocol.rs
@@ -100,3 +100,18 @@ fn protocol_2026_tools_list_includes_required_result_fields() {
         .as_array()
         .is_some_and(|tools| !tools.is_empty()));
 }
+
+#[test]
+fn get_index_changes_is_public_with_project_required() {
+    let result = tools_list_result("2026-07-28");
+    let tool = result["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|tool| tool["name"] == "get_index_changes")
+        .expect("public get_index_changes tool");
+    let required = tool["inputSchema"]["required"].as_array().unwrap();
+    assert!(required.contains(&json!("project")));
+    assert!(!required.contains(&json!("since_revision")));
+    assert_eq!(tool["annotations"]["readOnlyHint"], true);
+}


### PR DESCRIPTION
Closes #82.

## What
Freshness tracking for the index, in three layers:

1. **Index revision** — a monotonic counter persisted in \`IndexMeta\`, advanced by every persisted content change (fresh index, watcher batch flush, full resync). Loaded into \`SymbolIndex\` in memory (not serialized — no format break; pre-tracking indexes load cleanly at revision 0 via serde defaults). Every navigation response now carries \`index_revision\`: \`locate_code\`, \`read_code_unit\`, \`trace_path\`, \`analyze_impact\`, \`navigate_code\`, \`find_usages\`, \`find_callers\`, \`find_callees\`, \`get_file_outline\`, \`get_symbol\`, \`investigate\`.
2. **Change feed** — new public tool \`get_index_changes(project, since_revision?, limit?)\`: newest-first revision list with symbol-level diffs (added / removed / modified), distinct \`changed_symbols\`, and a \`complete\` flag. The log is bounded (latest 50 revisions, per-list caps of 200 IDs with \`truncated\`). Semantics are explicit: a revision is visible once the index flush lands; pending embedding work never delays it.
3. **Optional watching on startup** — \`ensure_project_ready\` starts the existing \`ProjectWatcher\` by default (\`watch: false\` opts out), so edits are applied incrementally after startup. The response reports watcher status in \`watching\` and degrades gracefully (\`unavailable\`) when no registry exists (CLI mode).

## Design notes
- \`meta.record_change()\` is the single writer for revision + log, so initial indexing, \`reindex_batch\`, and \`full_resync\` can't drift apart.
- Symbol IDs are file/name/kind based: content edits usually keep the ID and land in \`modified\`; renames appear as removed+added (documented).
- \`modified\` means "survived a reindexed file" — the ID scheme can't prove content change without per-symbol hashes; the wording in docs and response fields reflects that honestly.
- Revisions continue across re-indexes (never reset), so clients observing \`index_revision\` can never miss a change by re-baselining.

## Verification
- \`pitlane changes . --since 0\` on this repo: baseline revision 1, \`truncated: true\` on the capped added-list; non-forced re-runs stay cached at the same revision.
- New tests: meta back-compat defaults, monotonic revisions + log trimming, list caps + truncated flag, baseline feed from revision 0, watcher batch flush records revision + diff, end-to-end \`get_index_changes\` after a flush, \`watch=false\` / no-registry degradation, public-tier \`tools/list\` schema.

Suite: 656 lib tests + 4 protocol tests; clippy and rustfmt clean.