### PR TITLE
feat(knowledge): Markdown knowledge indexing + search_knowledge tool (Phase 1, towards #118)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Default public tier:
 - `get_index_stats`
 - `doctor`
 - `search_content`
+- `search_knowledge`
 
 Advanced primitive tools are hidden from `tools/list` unless the server is started with `PITLANE_MCP_TOOL_TIER=all`.
 
@@ -32,6 +33,7 @@ Advanced primitive tools are hidden from `tools/list` unless the server is start
 4. Use `trace_path` for behavior, source-to-sink, config-to-effect, shortest-path, and other execution-path questions.
 5. Use `analyze_impact` for blast-radius questions before edits or refactors. Use `analyze_changes` to map a Git diff to revision-qualified symbols, impact evidence, and test candidates.
 6. Use `search_content` when you know a text snippet, log string, import path, macro name, or regex fragment but do not know the symbol boundary yet.
+7. Use `search_knowledge` for documentation questions — it searches indexed Markdown (docs, READMEs, runbooks) by heading and content, with hybrid lexical/semantic ranking when embeddings exist.
 7. Use `get_index_stats` to orient yourself in unfamiliar repos before broader exploration.
 8. Fall back to direct file reads only when editing or when full-file context is genuinely required.
 9. Treat `read_code_unit` as the preferred diff-aware read surface. Use its `read_state.status` field to decide whether to reuse the payload, expand, or reread:

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -1,0 +1,59 @@
+# AGENT HANDOFF — Knowledge-Base Indexing (issue #118), Phase 1
+
+Branch: `feat/knowledge-indexing-phase1`
+
+## Objective
+Phase 1 of issue #118: generic knowledge-source abstraction + filesystem Markdown
+source, heading-aware section chunking with hierarchy metadata, reuse of existing
+BM25/embedding infrastructure, incremental re-indexing, and an MCP search tool.
+OKF-specific logic stays out of core; front matter is parsed into a generic
+metadata bag now so Phase 2 (OKF fields/relationships) can build on it.
+
+## Completed work
+- [x] Unit 1: `src/knowledge/document.rs` — `KnowledgeDocument`, `KnowledgeSection`,
+      heading-aware Markdown sectioning (pulldown_cmark), minimal YAML front-matter
+      subset parser, slug-based stable section IDs, embedding-text helper. Unit tests.
+
+## Important decisions
+- Separate storage under existing per-project index dir:
+  `~/.pitlane/indexes/<hash>/knowledge/` → `documents.bin`, `meta.json`,
+  `tantivy/` (sentinel `.ready.v1`), `embeddings.bin` (+`.meta.json`).
+  Code and knowledge indexes evolve independently; embedding *client/batch* infra
+  is reused but the store file is separate (different document profile).
+- IDs: doc_id = `knowledge:<relative/path.md>`; section key = `<doc_id>#<slug>`,
+  slug = slugified heading hierarchy, collision-suffixed (`-2`). Preamble sections
+  (text before first H1) use slug `preamble`. SymbolId is already a String alias,
+  so string IDs work with the existing EmbedStore type.
+- Section content = markdown from after its heading to the NEXT heading at ANY level
+  (leaf chunking, standard RAG style). Empty-content sections are kept for
+  navigation/line ranges but skipped for embeddings; BM25 indexes their name only.
+- Front matter: minimal YAML subset (top-level `key: value`, inline `[a, b]` lists,
+  block `- item` lists). Full YAML is a Phase 2 upgrade. Unknown keys preserved in
+  `front_matter` JSON bag for OKF extensibility.
+- Title resolution: front matter `title` > first H1 > file stem.
+- Tags from front matter `tags` and/or `categories`.
+
+## Files changed
+- `src/knowledge/mod.rs` (new, stub)
+- `src/knowledge/document.rs` (new)
+- `src/lib.rs` (add `pub mod knowledge;`)
+
+## Tests / results
+- `cargo test -p pitlane-mcp --lib knowledge::` → (fill in after run)
+
+## Unresolved issues
+- None yet. Watch for: pulldown_cmark 0.13 event API details; setext headings.
+
+## Next actions (in order, each atomic + tested)
+1. `src/index/knowledge_bm25.rs` — tantivy schema/build/ensure/search over sections
+   (fields: section_id [STRING|STORED], name, hierarchy, content, tags, file_path,
+   doc_title; reuse the "code" tokenizer approach or a plain text one), tests.
+2. `src/knowledge/mod.rs` — `ContentSource` trait + `FilesystemMarkdownSource`
+   (walk .md/.markdown, skip symlinks/binary/>1MiB, honor excludes),
+   `KnowledgeIndex` load/save/incremental (mtime+size+blake3 per file in meta.json),
+   tests.
+3. Embedding integration — knowledge section embedding docs + separate store under
+   `knowledge/`, reuse embed client; wire into index_project flow.
+4. `src/tools/search_knowledge.rs` — MCP tool (query, optional tag/path filters,
+   limit) with lexical BM25 + semantic hybrid when embeddings exist; register in
+   main.rs; update README/docs.

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -13,6 +13,12 @@ metadata bag now so Phase 2 (OKF fields/relationships) can build on it.
 - [x] Unit 1: `src/knowledge/document.rs` — `KnowledgeDocument`, `KnowledgeSection`,
       heading-aware Markdown sectioning (pulldown_cmark), minimal YAML front-matter
       subset parser, slug-based stable section IDs, embedding-text helper. Unit tests.
+- [x] Unit 2: `src/index/knowledge_bm25.rs` — tantivy schema/build/ensure/search over
+      sections (OR semantics, field boosts, shared "code" tokenizer + escape_query).
+- [x] Unit 3: `src/knowledge/mod.rs` — `ContentSource` trait + `MarkdownSource`,
+      `KnowledgeIndex` with incremental indexing (mtime+size fast path, blake3 hash
+      fallback), documents.bin/meta.json persistence under <index_dir>/knowledge/,
+      code-index exclusion policy (defaults + .gitignore + saved excludes).
 
 ## Important decisions
 - Separate storage under existing per-project index dir:
@@ -34,26 +40,28 @@ metadata bag now so Phase 2 (OKF fields/relationships) can build on it.
 - Tags from front matter `tags` and/or `categories`.
 
 ## Files changed
-- `src/knowledge/mod.rs` (new, stub)
+- `src/knowledge/mod.rs` (new)
 - `src/knowledge/document.rs` (new)
+- `src/index/knowledge_bm25.rs` (new)
+- `src/index/mod.rs` (declare module)
+- `src/index/format.rs` (add `knowledge_dir()`)
+- `src/index/bm25.rs` (pub(crate): register_tokenizer, TOKENIZER_NAME, escape_query)
 - `src/lib.rs` (add `pub mod knowledge;`)
 
 ## Tests / results
-- `cargo test -p pitlane-mcp --lib knowledge::` → (fill in after run)
+- `cargo test --lib` → 714 passed, 0 failed. Clippy clean.
+- Commits: 4ea9d62 (unit 1), bfccd44 (unit 2), a5b82bf (unit 3).
 
 ## Unresolved issues
-- None yet. Watch for: pulldown_cmark 0.13 event API details; setext headings.
+- None blocking. Notes: bincode cannot deserialize serde_json::Value → front matter
+  persisted as JSON string (accessor `front_matter_value()`). Setext headings fold
+  the whole preceding paragraph into the heading (CommonMark) — parser handles it.
 
 ## Next actions (in order, each atomic + tested)
-1. `src/index/knowledge_bm25.rs` — tantivy schema/build/ensure/search over sections
-   (fields: section_id [STRING|STORED], name, hierarchy, content, tags, file_path,
-   doc_title; reuse the "code" tokenizer approach or a plain text one), tests.
-2. `src/knowledge/mod.rs` — `ContentSource` trait + `FilesystemMarkdownSource`
-   (walk .md/.markdown, skip symlinks/binary/>1MiB, honor excludes),
-   `KnowledgeIndex` load/save/incremental (mtime+size+blake3 per file in meta.json),
-   tests.
-3. Embedding integration — knowledge section embedding docs + separate store under
-   `knowledge/`, reuse embed client; wire into index_project flow.
-4. `src/tools/search_knowledge.rs` — MCP tool (query, optional tag/path filters,
+1. Embedding integration — knowledge section embedding docs + separate store under
+   `knowledge/embeddings.bin`, reuse embed client; wire into index_project flow so
+   initial code indexing also indexes knowledge (BM25 ensure + embeddings when
+   configured).
+2. `src/tools/search_knowledge.rs` — MCP tool (query, optional tag/path filters,
    limit) with lexical BM25 + semantic hybrid when embeddings exist; register in
    main.rs; update README/docs.

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -19,6 +19,15 @@ metadata bag now so Phase 2 (OKF fields/relationships) can build on it.
       `KnowledgeIndex` with incremental indexing (mtime+size fast path, blake3 hash
       fallback), documents.bin/meta.json persistence under <index_dir>/knowledge/,
       code-index exclusion policy (defaults + .gitignore + saved excludes).
+- [x] Unit 4: `generate_knowledge_embeddings` in `src/knowledge/mod.rs` — section
+      embeddings via shared EmbedClient/EmbedStore infra into
+      `<index_dir>/knowledge/embeddings.bin`; hash-based skip; separate store file.
+- [x] Unit 5: `ensure_knowledge_index` orchestrator (incremental index → BM25
+      rebuild → persist; returns `(changed, KnowledgeIndex)`), `is_ready()` helper
+      in knowledge_bm25, and `src/tools/search_knowledge.rs` MCP tool with hybrid
+      lexical (BM25)/semantic (cosine) ranking, tag + path filters, pure-semantic
+      fallback scan, and lazy background embedding generation (deduped per
+      project). Registered in main.rs (project_field! + #[tool]) + docs.
 
 ## Important decisions
 - Separate storage under existing per-project index dir:
@@ -38,6 +47,11 @@ metadata bag now so Phase 2 (OKF fields/relationships) can build on it.
   `front_matter` JSON bag for OKF extensibility.
 - Title resolution: front matter `title` > first H1 > file stem.
 - Tags from front matter `tags` and/or `categories`.
+- `search_knowledge` builds the knowledge index lazily + incrementally on first use
+  (no code-index dependency). When `PITLANE_EMBED_*` are set, section embedding
+  generation is triggered from a background task after doc changes or when the
+  store/embed model is stale; a per-project `EMBED_INFLIGHT` set (RwLock) dedupes
+  concurrent spawns.
 
 ## Files changed
 - `src/knowledge/mod.rs` (new)
@@ -47,21 +61,28 @@ metadata bag now so Phase 2 (OKF fields/relationships) can build on it.
 - `src/index/format.rs` (add `knowledge_dir()`)
 - `src/index/bm25.rs` (pub(crate): register_tokenizer, TOKENIZER_NAME, escape_query)
 - `src/lib.rs` (add `pub mod knowledge;`)
+- `src/tools/search_knowledge.rs` (new MCP tool)
+- `src/tools/mod.rs` (declare module)
+- `src/main.rs` (SearchKnowledgeRequest + project_field! registration + #[tool] handler)
+- `AGENTS.md`, `README.md`, `docs/tools.md` (tool documentation)
 
 ## Tests / results
-- `cargo test --lib` → 714 passed, 0 failed. Clippy clean.
-- Commits: 4ea9d62 (unit 1), bfccd44 (unit 2), a5b82bf (unit 3).
+- `cargo test --lib` → 720 passed, 0 failed. Clippy clean, fmt clean.
+- Commits: 4ea9d62 (unit 1), bfccd44 (unit 2), a5b82bf (unit 3),
+  3f2c68f (unit 4), TBD (unit 5).
 
 ## Unresolved issues
 - None blocking. Notes: bincode cannot deserialize serde_json::Value → front matter
   persisted as JSON string (accessor `front_matter_value()`). Setext headings fold
   the whole preceding paragraph into the heading (CommonMark) — parser handles it.
+- Embedding dimension mismatch between a stale store and a freshly embedded section
+  is handled by skipping at save time (warn log) — a `force`/rebuild knob for the
+  knowledge store is not exposed yet (Phase 2 could add one via doctor/ensure).
 
-## Next actions (in order, each atomic + tested)
-1. Embedding integration — knowledge section embedding docs + separate store under
-   `knowledge/embeddings.bin`, reuse embed client; wire into index_project flow so
-   initial code indexing also indexes knowledge (BM25 ensure + embeddings when
-   configured).
-2. `src/tools/search_knowledge.rs` — MCP tool (query, optional tag/path filters,
-   limit) with lexical BM25 + semantic hybrid when embeddings exist; register in
-   main.rs; update README/docs.
+## Next actions
+1. (PR 1) Commit unit 5 as `closes #118`-style knowledge search feature branch work:
+   verify full suite after final fmt, commit with a message describing
+   `search_knowledge` tool, push branch, open PR (towards #118).
+2. Phase 2 (separate PR(s)): OKF metadata fields/relationships on the generic
+   front-matter bag; possibly a `force` embed rebuild knob and richer hybrid
+   weights documented.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Most users should stay on the default tool tier:
 5. Use `trace_path` for explicit source-to-sink or config-to-effect questions.
 6. Use `analyze_impact` before edits or refactors, and `analyze_changes` to review a Git diff.
 7. Use `search_content` only when you know a text fragment but not the owning symbol.
+8. Use `search_knowledge` for documentation questions — it searches indexed Markdown (docs, READMEs, runbooks) by heading and content.
 
 Default public tier:
 
@@ -158,6 +159,7 @@ Default public tier:
 - `analyze_changes`
 - `get_index_stats`
 - `search_content`
+- `search_knowledge`
 
 Advanced primitives are hidden from `tools/list` by default. Set `PITLANE_MCP_TOOL_TIER=all` to expose the full surface.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -201,6 +201,22 @@ Diagnose index health: freshness, effective exclusions, skipped oversized files,
 
 Every check carries a `status` (`ok`/`warn`/`error`/`info`), a `detail`, and — when something is wrong — a targeted `repair` hint. Set `"repair": true` to apply the safe repairs automatically: force re-index when the index is stale, and kick off background embedding when vectors are incomplete. Repairs only touch rebuildable artifacts (index, embeddings), never user files. Parse failures are not persisted historically, so `doctor` re-derives structural diagnostics at call time.
 
+### `search_knowledge`
+
+Search the project's Markdown knowledge base (docs, READMEs, runbooks) by heading
+and content.
+
+```json
+{ "project": "/your/project", "query": "how does retry with backoff work" }
+```
+
+Notes:
+
+- The index is built lazily and incrementally on first use; files are tracked by mtime/size plus a content hash, so re-calls only touch changed documents.
+- Ranking blends BM25 over section text/headings with semantic cosine similarity when `PITLANE_EMBED_URL`/`PITLANE_EMBED_MODEL` are set. Section embeddings generate in the background after changes; lexical results are always available without them.
+- Optional filters: `tag` (document front-matter tag, case-insensitive) and `path_filter` (substring of the relative file path).
+- Results include `file_path`, heading hierarchy, line range, a snippet, and score breakdown — open full sections with `read_code_unit` using those coordinates.
+
 ### `search_content`
 
 Search source, Markdown, JSON, YAML, and TOML text for a known snippet, log string,

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -212,7 +212,7 @@ and content.
 
 Notes:
 
-- The index is built lazily and incrementally on first use; files are tracked by mtime/size plus a content hash, so re-calls only touch changed documents.
+- The index is built lazily on first use. Each search hashes eligible Markdown files to catch edits even when timestamps and sizes are preserved; only changed documents are reparsed.
 - Ranking blends BM25 over section text/headings with semantic cosine similarity when `PITLANE_EMBED_URL`/`PITLANE_EMBED_MODEL` are set. Section embeddings generate in the background after changes; lexical results are always available without them.
 - Optional filters: `tag` (document front-matter tag, case-insensitive) and `path_filter` (substring of the relative file path).
 - Results include `file_path`, heading hierarchy, line range, a snippet, and score breakdown — open full sections with `read_code_unit` using those coordinates.

--- a/src/index/bm25.rs
+++ b/src/index/bm25.rs
@@ -24,7 +24,7 @@ use crate::sync_utils::{rw_read, rw_write};
 // ---------------------------------------------------------------------------
 
 /// Tokenizer name used in the schema and registered on every index.
-const TOKENIZER_NAME: &str = "code";
+pub(crate) const TOKENIZER_NAME: &str = "code";
 const READY_SENTINEL: &str = ".ready.v2";
 
 /// A tokenizer that splits on non-alphanumeric characters *and* at
@@ -149,7 +149,7 @@ fn tokenize_code(text: &str) -> Vec<Token> {
 
 /// Register the `"code"` tokenizer on `index`. Must be called before any
 /// write or read operation that touches TEXT fields.
-fn register_tokenizer(index: &Index) {
+pub(crate) fn register_tokenizer(index: &Index) {
     index
         .tokenizers()
         .register(TOKENIZER_NAME, CamelCaseTokenizer);
@@ -398,7 +398,7 @@ pub fn search(
     Ok(ids)
 }
 
-fn escape_query(s: &str) -> String {
+pub(crate) fn escape_query(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 8);
     for c in s.chars() {
         // Note: `'` must be escaped too — tantivy's QueryParser treats it as a

--- a/src/index/format.rs
+++ b/src/index/format.rs
@@ -226,6 +226,11 @@ pub fn index_dir(project_path: &Path) -> anyhow::Result<std::path::PathBuf> {
     Ok(home.join(".pitlane").join("indexes").join(hash))
 }
 
+/// Per-project knowledge index directory: `<index_dir>/knowledge`.
+pub fn knowledge_dir(project_path: &Path) -> anyhow::Result<std::path::PathBuf> {
+    Ok(index_dir(project_path)?.join("knowledge"))
+}
+
 fn dirs_home() -> anyhow::Result<std::path::PathBuf> {
     std::env::var("HOME")
         .map(std::path::PathBuf::from)

--- a/src/index/knowledge_bm25.rs
+++ b/src/index/knowledge_bm25.rs
@@ -126,6 +126,11 @@ pub fn build(docs: &[KnowledgeDocument], dir: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// True when a previously built BM25 index exists for `dir` (sentinel present).
+pub fn is_ready(dir: &Path) -> bool {
+    dir.join(READY_SENTINEL).exists()
+}
+
 /// Build only when the `.ready.v1` sentinel is absent.
 pub fn ensure(docs: &[KnowledgeDocument], dir: &Path) -> anyhow::Result<()> {
     if dir.join(READY_SENTINEL).exists() {

--- a/src/index/knowledge_bm25.rs
+++ b/src/index/knowledge_bm25.rs
@@ -1,0 +1,302 @@
+//! Tantivy BM25 index over knowledge sections (issue #118, Phase 1).
+//!
+//! Mirrors [`crate::index::bm25`] for code symbols but indexes heading-aware
+//! document sections instead. The two indexes are built and searched
+//! independently so code and knowledge retrieval can evolve separately; both
+//! reuse the shared `"code"` tokenizer, which also handles identifiers that
+//! appear in technical documentation.
+
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::{Arc, LazyLock, RwLock},
+};
+
+use anyhow::Context;
+use tantivy::{
+    collector::TopDocs,
+    directory::MmapDirectory,
+    query::QueryParser,
+    schema::{
+        Field, IndexRecordOption, Schema, TextFieldIndexing, TextOptions, Value, STORED, STRING,
+    },
+    Index, IndexReader, ReloadPolicy, TantivyDocument,
+};
+
+use crate::knowledge::document::KnowledgeDocument;
+use crate::sync_utils::{rw_read, rw_write};
+
+const READY_SENTINEL: &str = ".ready.v1";
+
+struct ReaderEntry {
+    index: Index,
+    reader: IndexReader,
+}
+
+struct KnowledgeFields {
+    section_id: Field,
+    name: Field,
+    hierarchy: Field,
+    content: Field,
+    tags: Field,
+    file_path: Field,
+    doc_title: Field,
+}
+
+impl KnowledgeFields {
+    fn load(schema: &Schema) -> anyhow::Result<Self> {
+        Ok(Self {
+            section_id: schema.get_field("section_id")?,
+            name: schema.get_field("name")?,
+            hierarchy: schema.get_field("hierarchy")?,
+            content: schema.get_field("content")?,
+            tags: schema.get_field("tags")?,
+            file_path: schema.get_field("file_path")?,
+            doc_title: schema.get_field("doc_title")?,
+        })
+    }
+}
+
+static READER_CACHE: LazyLock<RwLock<HashMap<PathBuf, Arc<ReaderEntry>>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+fn build_schema() -> Schema {
+    let mut b = Schema::builder();
+    // Only section_id is STORED; search fields are looked up from the
+    // in-memory document map after ranking (same trade-off as the code index).
+    b.add_text_field("section_id", STRING | STORED);
+    b.add_text_field("name", text());
+    b.add_text_field("hierarchy", text());
+    b.add_text_field("content", text());
+    b.add_text_field("tags", STRING);
+    b.add_text_field("file_path", STRING);
+    b.add_text_field("doc_title", text());
+    b.build()
+}
+
+/// TEXT field options using the shared `"code"` tokenizer.
+fn text() -> TextOptions {
+    TextOptions::default().set_indexing_options(
+        TextFieldIndexing::default()
+            .set_tokenizer(crate::index::bm25::TOKENIZER_NAME)
+            .set_index_option(IndexRecordOption::WithFreqsAndPositions),
+    )
+}
+
+/// Build the knowledge tantivy index from scratch into `dir`. Writes a ready
+/// sentinel on success; any partial write is cleaned up first.
+pub fn build(docs: &[KnowledgeDocument], dir: &Path) -> anyhow::Result<()> {
+    if dir.exists() {
+        std::fs::remove_dir_all(dir).with_context(|| format!("removing {}", dir.display()))?;
+    }
+    std::fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
+
+    let schema = build_schema();
+    let directory = MmapDirectory::open(dir)?;
+    let index = Index::open_or_create(directory, schema.clone())?;
+    crate::index::bm25::register_tokenizer(&index);
+    let mut writer = index.writer(50_000_000)?;
+    let fields = KnowledgeFields::load(&schema)?;
+
+    for doc in docs {
+        for section in &doc.sections {
+            let mut document = TantivyDocument::default();
+            document.add_text(fields.section_id, section.full_id(&doc.doc_id));
+            // The preamble has no heading of its own — the document title is
+            // its best name.
+            let name = if section.heading.is_empty() {
+                doc.title.as_str()
+            } else {
+                section.heading.as_str()
+            };
+            document.add_text(fields.name, name);
+            document.add_text(fields.hierarchy, section.hierarchy_path());
+            document.add_text(fields.content, &section.content);
+            for tag in &doc.tags {
+                document.add_text(fields.tags, tag);
+            }
+            document.add_text(fields.file_path, &doc.file_path);
+            document.add_text(fields.doc_title, &doc.title);
+            writer.add_document(document)?;
+        }
+    }
+
+    writer.commit()?;
+    std::fs::write(dir.join(READY_SENTINEL), b"")?;
+    Ok(())
+}
+
+/// Build only when the `.ready.v1` sentinel is absent.
+pub fn ensure(docs: &[KnowledgeDocument], dir: &Path) -> anyhow::Result<()> {
+    if dir.join(READY_SENTINEL).exists() {
+        return Ok(());
+    }
+    build(docs, dir)
+}
+
+/// Mark the on-disk knowledge BM25 index stale so the next `ensure` rebuilds.
+pub fn mark_stale(dir: &Path) -> anyhow::Result<()> {
+    let ready_path = dir.join(READY_SENTINEL);
+    match std::fs::remove_file(&ready_path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn get_or_open_reader(project: &Path, dir: &Path) -> anyhow::Result<Arc<ReaderEntry>> {
+    {
+        let cache = rw_read(&READER_CACHE);
+        if let Some(entry) = cache.get(project) {
+            return Ok(Arc::clone(entry));
+        }
+    }
+
+    let directory = MmapDirectory::open(dir)
+        .with_context(|| format!("opening knowledge tantivy dir {}", dir.display()))?;
+    let index = Index::open(directory)?;
+    crate::index::bm25::register_tokenizer(&index);
+    let reader = index
+        .reader_builder()
+        .reload_policy(ReloadPolicy::Manual)
+        .try_into()?;
+    let entry = Arc::new(ReaderEntry { index, reader });
+
+    rw_write(&READER_CACHE).insert(project.to_path_buf(), Arc::clone(&entry));
+    Ok(entry)
+}
+
+/// Evict the cached reader for `project` before rebuilding the index.
+pub fn invalidate(project: &Path) {
+    rw_write(&READER_CACHE).remove(project);
+}
+
+/// One ranked knowledge search hit.
+#[derive(Debug, Clone, PartialEq)]
+pub struct KnowledgeHit {
+    /// Full section ID: `knowledge:<path>#<slug>`.
+    pub section_id: String,
+    /// BM25 score (higher is better; not comparable across queries).
+    pub score: f32,
+}
+
+/// Search the knowledge index, returning sections in relevance order.
+///
+/// Uses OR semantics (any query term may match) — natural-language queries
+/// are less likely to have every term in a single section than code queries.
+pub fn search(
+    query_str: &str,
+    project: &Path,
+    dir: &Path,
+    fetch: usize,
+) -> anyhow::Result<Vec<KnowledgeHit>> {
+    if fetch == 0 || query_str.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let entry = get_or_open_reader(project, dir)?;
+    let searcher = entry.reader.searcher();
+    let fields = KnowledgeFields::load(searcher.schema())?;
+
+    let mut parser = QueryParser::for_index(
+        &entry.index,
+        vec![
+            fields.name,
+            fields.hierarchy,
+            fields.content,
+            fields.doc_title,
+        ],
+    );
+    // Name and hierarchy are the strongest signals for a section.
+    parser.set_field_boost(fields.name, 2.0);
+    parser.set_field_boost(fields.hierarchy, 1.5);
+    parser.set_field_boost(fields.doc_title, 1.2);
+
+    // Escape first (natural-language queries often contain apostrophes and
+    // colons); fall back to the raw query if parsing still fails.
+    let escaped = crate::index::bm25::escape_query(query_str);
+    let query = parser
+        .parse_query(&escaped)
+        .or_else(|_| parser.parse_query(query_str))
+        .with_context(|| format!("failed to parse knowledge BM25 query: {:?}", query_str))?;
+    let top_docs = searcher.search(&query, &TopDocs::with_limit(fetch).order_by_score())?;
+    let mut hits = Vec::with_capacity(top_docs.len());
+    for (score, doc_address) in top_docs {
+        let stored: TantivyDocument = searcher.doc(doc_address)?;
+        if let Some(v) = stored.get_first(fields.section_id) {
+            if let Some(section_id) = v.as_str() {
+                hits.push(KnowledgeHit {
+                    section_id: section_id.to_string(),
+                    score,
+                });
+            }
+        }
+    }
+    Ok(hits)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::knowledge::document::parse_markdown;
+
+    fn sample_docs() -> Vec<KnowledgeDocument> {
+        vec![
+            parse_markdown(
+                "docs/setup.md",
+                "---\ntitle: Setup Guide\ntags: [ops]\n---\n# Setup\nInstall the server.\n## Retry policy\nConfigure `retry_count` for transient failures.\n",
+            ),
+            parse_markdown("notes.md", "Random notes about billing.\n"),
+        ]
+    }
+
+    #[test]
+    fn build_and_search_rank_sections() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("tantivy");
+        let docs = sample_docs();
+        build(&docs, &dir).unwrap();
+        assert!(dir.join(READY_SENTINEL).exists());
+
+        // Rebuild idempotency via ensure: sentinel present → no-op.
+        ensure(&docs, &dir).unwrap();
+
+        let project = tmp.path();
+        let hits = search("retry_count", project, &dir, 5).unwrap();
+        assert!(!hits.is_empty());
+        assert_eq!(
+            hits[0].section_id,
+            "knowledge:docs/setup.md#setup-retry-policy"
+        );
+
+        let hits = search("billing", project, &dir, 5).unwrap();
+        assert_eq!(hits[0].section_id, "knowledge:notes.md#preamble");
+
+        // OR semantics: one matching term is enough.
+        let hits = search("nonexistentterm billing", project, &dir, 5).unwrap();
+        assert!(!hits.is_empty());
+
+        invalidate(project);
+    }
+
+    #[test]
+    fn mark_stale_forces_rebuild() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("tantivy");
+        let docs = sample_docs();
+        build(&docs, &dir).unwrap();
+        mark_stale(&dir).unwrap();
+        assert!(!dir.join(READY_SENTINEL).exists());
+        ensure(&docs, &dir).unwrap();
+        assert!(dir.join(READY_SENTINEL).exists());
+    }
+
+    #[test]
+    fn search_empty_query_returns_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("tantivy");
+        build(&sample_docs(), &dir).unwrap();
+        assert!(search("   ", tmp.path(), &dir, 5).unwrap().is_empty());
+        assert!(search("", tmp.path(), &dir, 0).unwrap().is_empty());
+    }
+}

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -1,5 +1,6 @@
 pub mod bm25;
 pub mod format;
+pub mod knowledge_bm25;
 pub mod repo_profile;
 
 use crate::graph::NavigationGraph;

--- a/src/knowledge/document.rs
+++ b/src/knowledge/document.rs
@@ -1,0 +1,559 @@
+//! Knowledge document model and Markdown parsing.
+//!
+//! A knowledge document is one source file (e.g. a Markdown page) parsed into
+//! heading-aware sections. Each section keeps its heading hierarchy and line
+//! range so retrieval results can be read back with exact coordinates, and the
+//! front matter is preserved as a generic metadata bag so OKF-specific fields
+//! (relationships, provenance, ...) can be modeled in later phases without
+//! changing the core structures.
+
+use std::collections::HashMap;
+
+use pulldown_cmark::{Event, Parser as MarkdownParser, Tag, TagEnd};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// A knowledge document — one source file parsed into heading-aware sections.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct KnowledgeDocument {
+    /// Stable identifier: `knowledge:<relative/path>`.
+    pub doc_id: String,
+    /// Path relative to the project root, forward slashes.
+    pub file_path: String,
+    /// Document title: front matter `title`, first H1 heading, or file stem.
+    pub title: String,
+    /// Tags/categories from front matter (`tags` / `categories`).
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// Raw front matter as compact JSON (empty string when absent) for fields
+    /// not yet modeled explicitly. Stored as a string because bincode cannot
+    /// deserialize `serde_json::Value` (it deserializes via `deserialize_any`).
+    #[serde(default)]
+    pub front_matter: String,
+    /// Heading-aware sections in document order.
+    pub sections: Vec<KnowledgeSection>,
+}
+
+impl KnowledgeDocument {
+    /// Stable identifier for a document at `relative_path`.
+    pub fn doc_id_for(relative_path: &str) -> String {
+        format!("knowledge:{relative_path}")
+    }
+
+    /// Parsed front matter (empty object when absent).
+    pub fn front_matter_value(&self) -> Value {
+        serde_json::from_str(&self.front_matter).unwrap_or(Value::Object(Map::new()))
+    }
+}
+
+/// A heading-delimited section of a knowledge document.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct KnowledgeSection {
+    /// Slugified heading hierarchy, unique within the document.
+    pub section_id: String,
+    /// This section's own heading text (empty for the preamble).
+    pub heading: String,
+    /// Full heading path from the document root, e.g. `["Setup", "Retry policy"]`.
+    #[serde(default)]
+    pub hierarchy: Vec<String>,
+    /// Heading level; 0 = preamble (content before the first heading).
+    pub level: usize,
+    /// Section body: Markdown source between this heading and the next heading
+    /// at any level.
+    pub content: String,
+    /// 1-based inclusive line range within the source file.
+    pub line_start: usize,
+    pub line_end: usize,
+}
+
+impl KnowledgeSection {
+    /// Full identifier used in the embedding store and BM25 index.
+    pub fn full_id(&self, doc_id: &str) -> String {
+        format!("{doc_id}#{}", self.section_id)
+    }
+
+    /// Heading path rendered as `A > B > C` (empty for the preamble).
+    pub fn hierarchy_path(&self) -> String {
+        self.hierarchy.join(" > ")
+    }
+
+    /// True when the section carries no body text. Such sections are kept for
+    /// navigation but skipped during embedding.
+    pub fn is_empty(&self) -> bool {
+        self.content.trim().is_empty()
+    }
+
+    /// Text embedded for this section: document context, heading path, body.
+    pub fn embedding_text(&self, doc: &KnowledgeDocument) -> String {
+        let mut text = doc.title.clone();
+        if !self.hierarchy.is_empty() {
+            text.push_str(" > ");
+            text.push_str(&self.hierarchy_path());
+        }
+        text.push('\n');
+        text.push_str(&self.content);
+        text
+    }
+}
+
+/// Parse Markdown `source` into a knowledge document for `relative_path`.
+pub fn parse_markdown(relative_path: &str, source: &str) -> KnowledgeDocument {
+    let (front_matter, body_start) = split_front_matter(source);
+    let body = &source[body_start..];
+
+    let line_starts = line_starts(source);
+    let total_lines = source.lines().count().max(1);
+
+    // Collect headings in document order. Offsets are relative to `body`.
+    struct Heading {
+        level: usize,
+        text: String,
+        start: usize,
+        end: usize,
+    }
+    let mut headings: Vec<Heading> = Vec::new();
+    let mut current: Option<usize> = None;
+    for (event, range) in MarkdownParser::new(body).into_offset_iter() {
+        match event {
+            Event::Start(Tag::Heading { level, .. }) => {
+                let idx = headings.len();
+                headings.push(Heading {
+                    level: level as usize,
+                    text: String::new(),
+                    start: range.start,
+                    end: body.len(),
+                });
+                current = Some(idx);
+            }
+            Event::Text(text) | Event::Code(text) if current.is_some() => {
+                headings[current.unwrap()].text.push_str(&text);
+            }
+            Event::SoftBreak | Event::HardBreak if current.is_some() => {
+                headings[current.unwrap()].text.push(' ');
+            }
+            Event::End(TagEnd::Heading(_)) => {
+                if let Some(idx) = current.take() {
+                    headings[idx].end = range.end;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Preamble: content before the first heading (or the whole document when
+    // there are no headings at all).
+    let mut sections: Vec<KnowledgeSection> = Vec::new();
+    let mut used_ids: HashMap<String, usize> = HashMap::new();
+    let preamble_end = headings.first().map(|h| h.start).unwrap_or(body.len());
+    if !body[..preamble_end].trim().is_empty() {
+        sections.push(KnowledgeSection {
+            section_id: "preamble".to_string(),
+            heading: String::new(),
+            hierarchy: Vec::new(),
+            level: 0,
+            content: body[..preamble_end].trim().to_string(),
+            line_start: line_of(&line_starts, body_start),
+            line_end: if preamble_end == body.len() {
+                total_lines
+            } else {
+                line_of(&line_starts, body_start + preamble_end - 1)
+            },
+        });
+        *used_ids.entry("preamble".to_string()).or_insert(0) += 1;
+    }
+
+    // One section per heading: body runs to the next heading at any level.
+    let mut stack: Vec<(usize, String)> = Vec::new();
+    for (i, h) in headings.iter().enumerate() {
+        while stack.last().is_some_and(|(level, _)| *level >= h.level) {
+            stack.pop();
+        }
+        let heading_text = h.text.trim().to_string();
+        stack.push((h.level, heading_text.clone()));
+        let hierarchy: Vec<String> = stack.iter().map(|(_, t)| t.clone()).collect();
+
+        let end = headings.get(i + 1).map(|n| n.start).unwrap_or(body.len());
+        let base = if heading_text.is_empty() {
+            "section".to_string()
+        } else {
+            slugify(&hierarchy.join(" "))
+        };
+        let count = used_ids.entry(base.clone()).or_insert(0);
+        *count += 1;
+        let section_id = if *count == 1 {
+            base
+        } else {
+            format!("{base}-{}", count)
+        };
+
+        sections.push(KnowledgeSection {
+            section_id,
+            heading: heading_text,
+            hierarchy,
+            level: h.level,
+            content: body[h.end..end].trim().to_string(),
+            line_start: line_of(&line_starts, body_start + h.start),
+            line_end: if end == body.len() {
+                total_lines
+            } else {
+                line_of(&line_starts, body_start + end - 1)
+            },
+        });
+    }
+
+    let title = extract_title(&front_matter)
+        .or_else(|| {
+            headings
+                .iter()
+                .find(|h| h.level == 1)
+                .map(|h| h.text.trim().to_string())
+                .filter(|t| !t.is_empty())
+        })
+        .unwrap_or_else(|| file_stem(relative_path));
+
+    KnowledgeDocument {
+        doc_id: KnowledgeDocument::doc_id_for(relative_path),
+        file_path: relative_path.to_string(),
+        title,
+        tags: extract_tags(&front_matter),
+        front_matter: if front_matter.is_null() {
+            String::new()
+        } else {
+            front_matter.to_string()
+        },
+        sections,
+    }
+}
+
+/// Byte offset of each line start in `source` (line 0 starts at 0).
+fn line_starts(source: &str) -> Vec<usize> {
+    std::iter::once(0)
+        .chain(source.match_indices('\n').map(|(i, _)| i + 1))
+        .collect()
+}
+
+/// 1-based line number containing byte offset `offset`.
+fn line_of(starts: &[usize], offset: usize) -> usize {
+    starts.partition_point(|start| *start <= offset)
+}
+
+/// Split leading YAML front matter from `source`.
+///
+/// Returns the parsed front matter (or `Value::Null`) and the byte offset where
+/// the document body begins. Only a minimal YAML subset is supported (top-level
+/// `key: value` pairs, inline `[a, b]` lists, block `- item` lists); full YAML
+/// parsing is a later-phase upgrade. Unknown keys are preserved verbatim.
+fn split_front_matter(source: &str) -> (Value, usize) {
+    let mut lines = source.split_inclusive('\n');
+    let Some(first) = lines.next() else {
+        return (Value::Null, 0);
+    };
+    if first.trim_end() != "---" {
+        return (Value::Null, 0);
+    }
+    let mut offset = first.len();
+    let mut block: Vec<&str> = Vec::new();
+    for line in lines {
+        if line.trim_end() == "---" || line.trim_end() == "..." {
+            return (parse_front_matter_block(&block), offset + line.len());
+        }
+        block.push(line);
+        offset += line.len();
+    }
+    // No closing delimiter — treat the file as plain Markdown.
+    (Value::Null, 0)
+}
+
+fn parse_front_matter_block(block: &[&str]) -> Value {
+    let mut obj = Map::new();
+    let mut list_key: Option<String> = None;
+    for raw in block {
+        let line = raw.trim_end();
+        let trimmed = line.trim_start();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let indented = line.starts_with(' ') || line.starts_with('\t');
+        if indented && trimmed.starts_with("- ") {
+            // Block list item under the most recent empty-valued key.
+            if let Some(key) = &list_key {
+                if let Some(Value::Array(items)) = obj.get_mut(key) {
+                    items.push(Value::String(parse_scalar(&trimmed[2..])));
+                }
+            }
+            continue;
+        }
+        if indented {
+            // Nested mappings are not modeled in Phase 1: drop the empty list
+            // placeholder that preceded them.
+            if let Some(key) = list_key.take() {
+                if matches!(obj.get(&key), Some(Value::Array(items)) if items.is_empty()) {
+                    obj.remove(&key);
+                }
+            }
+            continue;
+        }
+        list_key = None;
+        let Some(colon) = line.find(':') else {
+            continue;
+        };
+        let key = line[..colon].trim().to_string();
+        let value = line[colon + 1..].trim();
+        if key.is_empty() {
+            continue;
+        }
+        if value.is_empty() {
+            list_key = Some(key.clone());
+            obj.insert(key, Value::Array(Vec::new()));
+        } else if value.starts_with('[') && value.ends_with(']') {
+            let inner = &value[1..value.len() - 1];
+            let items: Vec<Value> = inner
+                .split(',')
+                .map(|s| Value::String(parse_scalar(s)))
+                .filter(|v| v.as_str().is_none_or(|s| !s.is_empty()))
+                .collect();
+            obj.insert(key, Value::Array(items));
+        } else {
+            obj.insert(key, Value::String(parse_scalar(value)));
+        }
+    }
+    Value::Object(obj)
+}
+
+fn parse_scalar(s: &str) -> String {
+    let s = s.trim();
+    if s.len() >= 2
+        && ((s.starts_with('"') && s.ends_with('"')) || (s.starts_with('\'') && s.ends_with('\'')))
+    {
+        s[1..s.len() - 1].to_string()
+    } else {
+        s.to_string()
+    }
+}
+
+/// Front matter `title`, when present and non-empty.
+fn extract_title(fm: &Value) -> Option<String> {
+    fm.get("title")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .map(str::to_string)
+}
+
+/// Front matter `tags` and/or `categories`, as a flat list of strings.
+fn extract_tags(fm: &Value) -> Vec<String> {
+    let mut tags = Vec::new();
+    for key in ["tags", "categories"] {
+        let Some(value) = fm.get(key) else {
+            continue;
+        };
+        match value {
+            Value::Array(items) => {
+                for item in items {
+                    if let Some(s) = item.as_str().map(str::trim).filter(|s| !s.is_empty()) {
+                        tags.push(s.to_string());
+                    }
+                }
+            }
+            Value::String(s) => {
+                for part in s.split(',') {
+                    let part = part.trim();
+                    if !part.is_empty() {
+                        tags.push(part.to_string());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    tags
+}
+
+/// Lowercase, hyphen-separated slug of `s` (non-alphanumeric runs → `-`).
+fn slugify(s: &str) -> String {
+    let mut out = String::new();
+    for c in s.chars() {
+        if c.is_alphanumeric() {
+            out.push(c.to_lowercase().next().unwrap());
+        } else if !out.ends_with('-') {
+            out.push('-');
+        }
+    }
+    let trimmed = out.trim_matches('-').to_string();
+    if trimmed.is_empty() {
+        "section".to_string()
+    } else {
+        trimmed
+    }
+}
+
+/// File stem (no directory, no final extension) of a relative path.
+fn file_stem(relative_path: &str) -> String {
+    let name = relative_path.rsplit('/').next().unwrap_or(relative_path);
+    match name.rfind('.') {
+        Some(i) if i > 0 => name[..i].to_string(),
+        _ => name.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sections_keep_hierarchy_content_and_line_ranges() {
+        let source =
+            "# Setup\nIntro text.\n## **Retry** `policy`\nDetails here.\n## Other\nMore.\n";
+        let doc = parse_markdown("docs/setup.md", source);
+        assert_eq!(doc.doc_id, "knowledge:docs/setup.md");
+        assert_eq!(doc.title, "Setup");
+        assert_eq!(doc.sections.len(), 3);
+
+        // Preamble under H1? No — "Intro text." belongs to the Setup section.
+        let setup = &doc.sections[0];
+        assert_eq!(setup.section_id, "setup");
+        assert_eq!(setup.heading, "Setup");
+        assert_eq!(setup.hierarchy, vec!["Setup".to_string()]);
+        assert_eq!(setup.level, 1);
+        assert_eq!(setup.content.trim(), "Intro text.");
+        assert_eq!((setup.line_start, setup.line_end), (1, 2));
+
+        let retry = &doc.sections[1];
+        assert_eq!(retry.section_id, "setup-retry-policy");
+        assert_eq!(retry.heading, "Retry policy");
+        assert_eq!(
+            retry.hierarchy,
+            vec!["Setup".to_string(), "Retry policy".to_string()]
+        );
+        assert_eq!(retry.content.trim(), "Details here.");
+
+        let other = &doc.sections[2];
+        assert_eq!(other.section_id, "setup-other");
+        assert_eq!((other.line_start, other.line_end), (5, 6));
+    }
+
+    #[test]
+    fn preamble_and_headingless_documents() {
+        let doc = parse_markdown("notes.md", "Just a note.\n# Title\nBody.\n");
+        assert_eq!(doc.sections.len(), 2);
+        assert_eq!(doc.sections[0].section_id, "preamble");
+        assert_eq!(doc.sections[0].level, 0);
+        assert_eq!(doc.sections[0].content.trim(), "Just a note.");
+
+        let doc = parse_markdown("plain.md", "No headings at all.\n");
+        assert_eq!(doc.sections.len(), 1);
+        assert_eq!(doc.sections[0].section_id, "preamble");
+        assert_eq!(doc.title, "plain");
+    }
+
+    #[test]
+    fn code_blocks_and_setext_headings_are_handled() {
+        // Blank line before the setext heading: without it, CommonMark folds
+        // the whole preceding paragraph ("Text. Final") into the heading.
+        let source =
+            "# Top\n```md\n# Fake heading inside code\n```\n## Sub\nText.\n\nFinal\n=====\nEnd.\n";
+        let doc = parse_markdown("a.md", source);
+        let ids: Vec<_> = doc.sections.iter().map(|s| s.section_id.as_str()).collect();
+        assert_eq!(ids, vec!["top", "top-sub", "final"]);
+        // The fenced "# Fake heading" must not create a section.
+        assert!(!doc.sections.iter().any(|s| s.heading.contains("Fake")));
+    }
+
+    #[test]
+    fn duplicate_headings_get_colliding_slugs() {
+        let source = "# A\n## X\none\n## X\ntwo\n# B\n## X\nthree\n";
+        let doc = parse_markdown("a.md", source);
+        let ids: Vec<_> = doc.sections.iter().map(|s| s.section_id.as_str()).collect();
+        assert_eq!(ids, vec!["a", "a-x", "a-x-2", "b", "b-x"]);
+    }
+
+    #[test]
+    fn empty_sections_are_flagged_but_kept() {
+        let source = "# API\n## GET /users\nReturns users.\n";
+        let doc = parse_markdown("api.md", source);
+        assert_eq!(doc.sections.len(), 2);
+        assert!(doc.sections[0].is_empty());
+        assert!(!doc.sections[1].is_empty());
+        assert_eq!(
+            doc.sections[1].full_id(&doc.doc_id),
+            "knowledge:api.md#api-get-users"
+        );
+    }
+
+    #[test]
+    fn front_matter_provides_title_tags_and_metadata_bag() {
+        let source = "---\ntitle: \"Retry Guide\"\ntags: [ops, retry]\ncategories:\n  - runbook\nokf_version: v1\n---\n# Heading\nBody.\n";
+        let doc = parse_markdown("guide.md", source);
+        assert_eq!(doc.title, "Retry Guide");
+        assert_eq!(
+            doc.tags,
+            vec![
+                "ops".to_string(),
+                "retry".to_string(),
+                "runbook".to_string()
+            ]
+        );
+        assert_eq!(
+            doc.front_matter_value()["okf_version"],
+            Value::String("v1".into())
+        );
+        // Body line numbers account for the front matter lines.
+        let heading = &doc.sections[0];
+        assert_eq!(heading.line_start, 8);
+        assert_eq!(doc.sections.len(), 1);
+    }
+
+    #[test]
+    fn missing_front_matter_falls_back_to_h1_or_stem() {
+        let doc = parse_markdown("deep/dir/page.md", "Body only.\n");
+        assert_eq!(doc.title, "page");
+        let doc = parse_markdown("x.md", "# The Title\nBody.\n");
+        assert_eq!(doc.title, "The Title");
+    }
+
+    #[test]
+    fn unterminated_front_matter_is_treated_as_body() {
+        let source = "---\ntitle: never closed\n# Real\nBody.\n";
+        let doc = parse_markdown("a.md", source);
+        assert_eq!(doc.front_matter, String::new());
+        // The first line is a code-fence-like boundary only when paired; here
+        // pulldown sees it as text, so the whole thing is one preamble section.
+        assert!(doc.sections.iter().any(|s| s.section_id == "preamble"));
+    }
+
+    #[test]
+    fn front_matter_list_edge_cases() {
+        let source =
+            "---\ntags: []\nempty:\n  - a\nnested:\n  deep: value\nok: 'yes'\n---\nBody.\n";
+        let doc = parse_markdown("a.md", source);
+        assert_eq!(doc.tags, Vec::<String>::new());
+        let fm = doc.front_matter_value();
+        assert_eq!(fm["empty"], Value::Array(vec![Value::String("a".into())]));
+        // Nested mappings are skipped in Phase 1.
+        assert!(fm.get("nested").is_none());
+        assert_eq!(fm["ok"], Value::String("yes".into()));
+    }
+
+    #[test]
+    fn embedding_text_includes_document_context() {
+        let source = "# Setup\n## Retry policy\nUse `retry_count`.\n";
+        let doc = parse_markdown("docs/setup.md", source);
+        let retry = &doc.sections[1];
+        assert_eq!(
+            retry.embedding_text(&doc),
+            "Setup > Setup > Retry policy\nUse `retry_count`."
+        );
+    }
+
+    #[test]
+    fn round_trip_serialization() {
+        let source = "# A\n## B\ntext\n";
+        let doc = parse_markdown("a.md", source);
+        let bytes = bincode::serde::encode_to_vec(&doc, bincode::config::standard()).unwrap();
+        let loaded: KnowledgeDocument =
+            bincode::serde::decode_from_slice(&bytes, bincode::config::standard())
+                .unwrap()
+                .0;
+        assert_eq!(loaded, doc);
+    }
+}

--- a/src/knowledge/mod.rs
+++ b/src/knowledge/mod.rs
@@ -14,6 +14,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::SystemTime;
 
+use anyhow::Context as _;
 use futures::StreamExt;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use serde::{Deserialize, Serialize};
@@ -299,6 +300,44 @@ impl KnowledgeIndex {
         self.meta.files = current_files;
         Ok(IndexResult { parsed, removed })
     }
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+/// Load persisted knowledge state, incrementally index changed files under
+/// `root`, and keep the BM25 index in sync. Persists documents/meta when
+/// anything changed.
+///
+/// Returns `(changed, index)` where `changed` is true when document content was
+/// added/changed/removed (the caller may then want to refresh embeddings).
+pub fn ensure_knowledge_index(root: &Path) -> anyhow::Result<(bool, KnowledgeIndex)> {
+    let dir = crate::index::format::knowledge_dir(root)?;
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("creating knowledge dir {}", dir.display()))?;
+
+    let mut index = KnowledgeIndex::load(&dir)?;
+    let result = index.index_project(root, &MarkdownSource)?;
+
+    if !result.anything_changed() {
+        // Documents unchanged: make sure BM25 exists (it may have been deleted).
+        let bm25_dir = dir.join("tantivy");
+        if !crate::index::knowledge_bm25::is_ready(&bm25_dir) {
+            crate::index::knowledge_bm25::invalidate(root);
+            let docs: Vec<document::KnowledgeDocument> =
+                index.documents.values().cloned().collect();
+            crate::index::knowledge_bm25::build(&docs, &bm25_dir)?;
+        }
+        return Ok((false, index));
+    }
+
+    // Documents changed: rebuild BM25, then persist documents + meta.
+    crate::index::knowledge_bm25::invalidate(root);
+    let docs: Vec<document::KnowledgeDocument> = index.documents.values().cloned().collect();
+    crate::index::knowledge_bm25::build(&docs, &dir.join("tantivy"))?;
+    index.save(&dir)?;
+    Ok((true, index))
 }
 
 // ---------------------------------------------------------------------------

--- a/src/knowledge/mod.rs
+++ b/src/knowledge/mod.rs
@@ -10,8 +10,8 @@ pub mod document;
 
 use std::collections::{HashMap, HashSet};
 use std::io::Write as _;
-use std::path::Path;
-use std::sync::Arc;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, LazyLock, Mutex};
 use std::time::SystemTime;
 
 use anyhow::Context as _;
@@ -199,9 +199,8 @@ impl KnowledgeIndex {
 
     /// Incrementally index all files handled by `source` under `root`.
     ///
-    /// Files whose mtime and size match the persisted state are not re-read;
-    /// a content hash catches edits that preserve both. Unchanged documents
-    /// are kept in memory from the previous load.
+    /// Hash eligible files on every pass to detect edits that preserve mtime
+    /// and size. Only changed documents are reparsed.
     pub fn index_project(
         &mut self,
         root: &Path,
@@ -251,14 +250,6 @@ impl KnowledgeIndex {
             let mtime = mtime_secs(metadata.modified().ok());
             let size = metadata.len();
 
-            // Fast path: mtime + size unchanged → keep the existing document.
-            if let Some(state) = self.meta.files.get(&rel_str) {
-                if state.mtime == mtime && state.size == size {
-                    current_files.insert(rel_str, state.clone());
-                    continue;
-                }
-            }
-
             let bytes = read_regular_file(path)?;
             let Ok(text) = std::str::from_utf8(&bytes) else {
                 tracing::warn!(file = %rel_str, "skipping non-UTF-8 knowledge file");
@@ -266,9 +257,13 @@ impl KnowledgeIndex {
             };
             let hash = crate::embed::document::document_hash(text);
 
-            // Slow path: mtime/size drifted — the hash decides.
+            // Reuse parsed content only when its hash still matches.
             if let Some(state) = self.meta.files.get(&rel_str) {
-                if state.hash == hash {
+                if state.hash == hash
+                    && self
+                        .documents
+                        .contains_key(&document::KnowledgeDocument::doc_id_for(&rel_str))
+                {
                     current_files.insert(rel_str, FileState { mtime, size, hash });
                     continue;
                 }
@@ -313,6 +308,30 @@ impl KnowledgeIndex {
 /// Returns `(changed, index)` where `changed` is true when document content was
 /// added/changed/removed (the caller may then want to refresh embeddings).
 pub fn ensure_knowledge_index(root: &Path) -> anyhow::Result<(bool, KnowledgeIndex)> {
+    with_knowledge_index(root, |changed, index| Ok((changed, index)))
+}
+
+static INDEX_LOCKS: LazyLock<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Keep indexing and the associated lexical read in one project transaction.
+pub(crate) fn with_knowledge_index<T>(
+    root: &Path,
+    read: impl FnOnce(bool, KnowledgeIndex) -> anyhow::Result<T>,
+) -> anyhow::Result<T> {
+    let canonical = root.canonicalize()?;
+    let lock = INDEX_LOCKS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .entry(canonical.clone())
+        .or_default()
+        .clone();
+    let _guard = lock.lock().unwrap_or_else(|e| e.into_inner());
+    let (changed, index) = ensure_knowledge_index_unlocked(&canonical)?;
+    read(changed, index)
+}
+
+fn ensure_knowledge_index_unlocked(root: &Path) -> anyhow::Result<(bool, KnowledgeIndex)> {
     let dir = crate::index::format::knowledge_dir(root)?;
     std::fs::create_dir_all(&dir)
         .with_context(|| format!("creating knowledge dir {}", dir.display()))?;
@@ -684,7 +703,7 @@ mod tests {
             .unwrap()
             .modified()
             .unwrap();
-        std::fs::write(&path, "# A\nEdited.\n").unwrap();
+        std::fs::write(&path, "# A\nModified.\n").unwrap();
         File::open(&path).unwrap().set_modified(old_mtime).unwrap();
 
         let result = index.index_project(&root, &MarkdownSource).unwrap();
@@ -692,7 +711,7 @@ mod tests {
         assert!(index.documents["knowledge:a.md"]
             .sections
             .iter()
-            .any(|s| s.content.contains("Edited")));
+            .any(|s| s.content.contains("Modified")));
     }
 
     #[test]

--- a/src/knowledge/mod.rs
+++ b/src/knowledge/mod.rs
@@ -1,0 +1,7 @@
+//! Knowledge-base indexing (issue #118, Phase 1).
+//!
+//! Generic content-source abstraction with a filesystem Markdown source.
+//! Documents are parsed into heading-aware sections that carry hierarchy and
+//! front-matter metadata, ready for OKF-specific fields in later phases.
+
+pub mod document;

--- a/src/knowledge/mod.rs
+++ b/src/knowledge/mod.rs
@@ -11,12 +11,19 @@ pub mod document;
 use std::collections::{HashMap, HashSet};
 use std::io::Write as _;
 use std::path::Path;
+use std::sync::Arc;
 use std::time::SystemTime;
 
+use futures::StreamExt;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use serde::{Deserialize, Serialize};
 use walkdir::WalkDir;
 
+use crate::embed::client::{
+    effective_batch_size, effective_max_concurrency, effective_request_delay_ms, EmbedClient,
+};
+use crate::embed::store::{EmbedStore, EmbedStoreMetadata};
+use crate::embed::EmbedConfig;
 use crate::indexer::extra_excluded_dir_names;
 use crate::path_policy::{read_regular_file, regular_file_metadata};
 
@@ -294,6 +301,161 @@ impl KnowledgeIndex {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Embeddings
+// ---------------------------------------------------------------------------
+
+/// Generate embeddings for every non-empty section of `docs` and save to
+/// `store_path`. Sections whose stored document hash matches are skipped,
+/// so re-runs only embed new or changed sections. Uses the same client,
+/// batching, and store format as code embeddings but a separate store file.
+pub async fn generate_knowledge_embeddings(
+    docs: &[document::KnowledgeDocument],
+    config: &EmbedConfig,
+    store_path: &Path,
+) -> crate::embed::EmbedResult {
+    let start = std::time::Instant::now();
+
+    let section_docs: Vec<(String, String, u64)> = docs
+        .iter()
+        .flat_map(|doc| {
+            doc.sections.iter().filter(|s| !s.is_empty()).map(|s| {
+                let text = s.embedding_text(doc);
+                let hash = crate::embed::document::document_hash(&text);
+                (s.full_id(&doc.doc_id), text, hash)
+            })
+        })
+        .collect();
+
+    let mut store = EmbedStore::load(store_path).unwrap_or_default();
+    let fingerprint = crate::embed::document::document_fingerprint(&config.model);
+    let compatible = EmbedStoreMetadata::load(store_path)
+        .ok()
+        .flatten()
+        .is_some_and(|meta| {
+            meta.is_compatible(
+                &config.model,
+                &fingerprint,
+                &crate::embed::endpoint_fingerprint(&config.url, &config.headers),
+            )
+        });
+    if !compatible {
+        store = EmbedStore::new();
+    }
+
+    // Drop vectors for sections that no longer exist.
+    let live_ids: HashSet<String> = section_docs.iter().map(|(id, _, _)| id.clone()).collect();
+    store.retain_ids(&live_ids);
+
+    let to_embed: Vec<(String, String, u64)> = section_docs
+        .into_iter()
+        .filter(|(id, _, hash)| {
+            !store.vectors.contains_key(id) || store.hashes.get(id) != Some(hash)
+        })
+        .collect();
+
+    let total = to_embed.len();
+    let mut stored = 0usize;
+    let mut skipped = 0usize;
+
+    if total > 0 {
+        tracing::info!(total, "knowledge-embed: starting embedding generation");
+        let client = Arc::new(EmbedClient::new(Arc::new(EmbedConfig {
+            url: config.url.clone(),
+            model: config.model.clone(),
+            headers: config.headers.clone(),
+        })));
+
+        let batch_size = effective_batch_size();
+        let chunks: Vec<Vec<(String, String, u64)>> = to_embed
+            .chunks(batch_size)
+            .map(|chunk| chunk.to_vec())
+            .collect();
+        let total_chunks = chunks.len();
+        let request_delay_ms = effective_request_delay_ms();
+
+        let chunk_futures = chunks.into_iter().enumerate().map(|(i, chunk)| {
+            let client = Arc::clone(&client);
+            async move {
+                if request_delay_ms > 0 && i > 0 {
+                    tokio::time::sleep(std::time::Duration::from_millis(request_delay_ms)).await;
+                }
+                let texts: Vec<String> = chunk.iter().map(|(_, t, _)| t.clone()).collect();
+                let ids: Vec<String> = chunk.iter().map(|(id, _, _)| id.clone()).collect();
+                let hashes: Vec<u64> = chunk.iter().map(|(_, _, h)| *h).collect();
+                let results = client.embed_batch(&texts).await;
+                (
+                    i,
+                    ids.into_iter().zip(results).zip(hashes).collect::<Vec<_>>(),
+                )
+            }
+        });
+
+        let mut completed = 0usize;
+        let mut stream =
+            futures::stream::iter(chunk_futures).buffer_unordered(effective_max_concurrency());
+        while let Some((chunk_idx, batch)) = stream.next().await {
+            let batch_len = batch.len();
+            for ((id, maybe_vec), hash) in batch {
+                match maybe_vec {
+                    Some(vec) => {
+                        if let Some(existing_dim) = store.dimension() {
+                            if vec.len() != existing_dim {
+                                tracing::warn!(
+                                    "knowledge-embed: dimension mismatch for {id}: got {} expected {existing_dim}; skipping",
+                                    vec.len()
+                                );
+                                skipped += 1;
+                                continue;
+                            }
+                        }
+                        store.update(id.clone(), vec);
+                        store.hashes.insert(id, hash);
+                        stored += 1;
+                    }
+                    None => skipped += 1,
+                }
+            }
+            completed += batch_len;
+            let is_last = chunk_idx + 1 == total_chunks;
+            if chunk_idx % 10 == 0 || is_last {
+                tracing::info!(
+                    completed,
+                    total,
+                    stored,
+                    skipped,
+                    "knowledge-embed: progress"
+                );
+            }
+        }
+    }
+
+    let error = match store.save(store_path).and_then(|_| {
+        EmbedStoreMetadata {
+            format_version: crate::embed::document::DOCUMENT_FORMAT_VERSION,
+            model: config.model.clone(),
+            dimension: store.dimension().unwrap_or(0),
+            document_fingerprint: fingerprint,
+            endpoint_fingerprint: crate::embed::endpoint_fingerprint(&config.url, &config.headers),
+        }
+        .save(store_path)
+    }) {
+        Ok(()) => None,
+        Err(e) => {
+            let msg = format!("failed to write knowledge embeddings store: {e}");
+            tracing::error!("{msg}");
+            Some(msg)
+        }
+    };
+
+    crate::embed::EmbedResult {
+        stored,
+        skipped,
+        elapsed_ms: start.elapsed().as_millis() as u64,
+        error,
+    }
+}
+
 fn atomic_write(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
     let tmp = path.with_extension("tmp");
     let mut file = std::fs::File::create(&tmp)?;
@@ -365,7 +527,10 @@ fn should_descend(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::embed::store::EmbedStore;
     use crate::knowledge::document::parse_markdown;
+    use reqwest::header::HeaderMap;
+    use serde_json::{json, Value};
     use std::fs::File;
     use std::path::PathBuf;
 
@@ -538,5 +703,108 @@ mod tests {
         let result = index.index_project(&root, &MarkdownSource).unwrap();
         assert_eq!(result.parsed, 1);
         assert!(index.documents.contains_key("knowledge:visible.md"));
+    }
+
+    fn embed_config(url: String) -> EmbedConfig {
+        EmbedConfig {
+            url,
+            model: "test".into(),
+            headers: HeaderMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn generate_knowledge_embeddings_stores_and_skips_unchanged() {
+        use httpmock::prelude::*;
+        let docs = vec![parse_markdown(
+            "docs/setup.md",
+            "# Setup\nInstall the server.\n## Retry policy\nConfigure `retry_count`.\n## Empty heading\n",
+        )];
+        let data: Vec<Value> = (0..4u32)
+            .map(|i| json!({"index": i, "embedding": [f64::from(i), 1.0 - f64::from(i) / 4.0]}))
+            .collect();
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(json!({"data": data}).to_string());
+        });
+
+        let dir = tempfile::tempdir().unwrap();
+        let store_path = dir.path().join("embeddings.bin");
+        let config = embed_config(server.url("/"));
+
+        // Two non-empty sections ("setup", "setup-retry-policy"); the empty one is skipped.
+        let result = generate_knowledge_embeddings(&docs, &config, &store_path).await;
+        assert_eq!(result.stored, 2);
+        assert!(result.error.is_none());
+
+        // Second run: hashes match → nothing to embed.
+        let result = generate_knowledge_embeddings(&docs, &config, &store_path).await;
+        assert_eq!((result.stored, result.skipped), (0, 0));
+
+        let store = EmbedStore::load(&store_path).unwrap();
+        assert!(store.vectors.contains_key("knowledge:docs/setup.md#setup"));
+        assert!(store
+            .vectors
+            .contains_key("knowledge:docs/setup.md#setup-retry-policy"));
+        // Empty section must not be embedded.
+        // Empty section must not be embedded (slug includes parent: "setup-empty-heading").
+        assert!(!store
+            .vectors
+            .contains_key("knowledge:docs/setup.md#setup-empty-heading"));
+    }
+
+    #[tokio::test]
+    async fn changed_sections_reembedded_removed_dropped() {
+        use httpmock::prelude::*;
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    json!({"data": [
+                        {"index": 0, "embedding": [1.0]},
+                        {"index": 1, "embedding": [0.5]}
+                    ]})
+                    .to_string(),
+                );
+        });
+
+        let dir = tempfile::tempdir().unwrap();
+        let store_path = dir.path().join("embeddings.bin");
+        let config = embed_config(server.url("/"));
+
+        let v1 = vec![parse_markdown("a.md", "# A\nOne.\n## B\nTwo.\n")];
+        assert_eq!(
+            generate_knowledge_embeddings(&v1, &config, &store_path)
+                .await
+                .stored,
+            2
+        );
+
+        // Edit section A only → one re-embed.
+        let v2 = vec![parse_markdown("a.md", "# A\nOne, edited.\n## B\nTwo.\n")];
+        assert_eq!(
+            generate_knowledge_embeddings(&v2, &config, &store_path)
+                .await
+                .stored,
+            1
+        );
+
+        // Drop section B → its vector is removed.
+        let v3 = vec![parse_markdown("a.md", "# A\nOne, edited.\n")];
+        assert_eq!(
+            generate_knowledge_embeddings(&v3, &config, &store_path)
+                .await
+                .stored,
+            0
+        );
+
+        let store = EmbedStore::load(&store_path).unwrap();
+        assert_eq!(store.vectors.len(), 1);
+        assert!(store.vectors.contains_key("knowledge:a.md#a"));
     }
 }

--- a/src/knowledge/mod.rs
+++ b/src/knowledge/mod.rs
@@ -704,7 +704,13 @@ mod tests {
             .modified()
             .unwrap();
         std::fs::write(&path, "# A\nModified.\n").unwrap();
-        File::open(&path).unwrap().set_modified(old_mtime).unwrap();
+        // Windows requires write access to update file timestamps.
+        File::options()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_modified(old_mtime)
+            .unwrap();
 
         let result = index.index_project(&root, &MarkdownSource).unwrap();
         assert_eq!(result.parsed, 1);

--- a/src/knowledge/mod.rs
+++ b/src/knowledge/mod.rs
@@ -1,7 +1,542 @@
 //! Knowledge-base indexing (issue #118, Phase 1).
 //!
-//! Generic content-source abstraction with a filesystem Markdown source.
-//! Documents are parsed into heading-aware sections that carry hierarchy and
-//! front-matter metadata, ready for OKF-specific fields in later phases.
+//! A generic content-source abstraction with a filesystem Markdown source.
+//! Documents are parsed into heading-aware sections (see [`document`]) and
+//! persisted per project under `<index_dir>/knowledge/` alongside the code
+//! index. Code and knowledge indexing evolve independently: this module owns
+//! its own walk, persistence format, and BM25 schema.
 
 pub mod document;
+
+use std::collections::{HashMap, HashSet};
+use std::io::Write as _;
+use std::path::Path;
+use std::time::SystemTime;
+
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use serde::{Deserialize, Serialize};
+use walkdir::WalkDir;
+
+use crate::indexer::extra_excluded_dir_names;
+use crate::path_policy::{read_regular_file, regular_file_metadata};
+
+/// Files larger than this are skipped (same limit as code indexing).
+const MAX_KNOWLEDGE_FILE_BYTES: u64 = 1024 * 1024; // 1 MiB
+
+/// Bump when the persisted knowledge layout changes incompatibly.
+pub const KNOWLEDGE_META_VERSION: u32 = 1;
+
+// ---------------------------------------------------------------------------
+// Content sources
+// ---------------------------------------------------------------------------
+
+/// A source of knowledge content. Phase 1 ships [`MarkdownSource`]; later
+/// phases can add OKF/Confluence-backed sources without touching the indexing
+/// core.
+pub trait ContentSource {
+    /// Stable name, e.g. `"markdown"`.
+    fn name(&self) -> &'static str;
+
+    /// File extensions this source handles (lowercase, no dot).
+    fn extensions(&self) -> &[&str];
+
+    /// Parse raw file text into a knowledge document. `relative_path` uses
+    /// forward slashes and is relative to the project root.
+    fn parse(&self, relative_path: &str, text: &str)
+        -> anyhow::Result<document::KnowledgeDocument>;
+}
+
+/// Filesystem Markdown source (`.md` / `.markdown`).
+#[derive(Default)]
+pub struct MarkdownSource;
+
+impl ContentSource for MarkdownSource {
+    fn name(&self) -> &'static str {
+        "markdown"
+    }
+
+    fn extensions(&self) -> &[&str] {
+        &["md", "markdown"]
+    }
+
+    fn parse(
+        &self,
+        relative_path: &str,
+        text: &str,
+    ) -> anyhow::Result<document::KnowledgeDocument> {
+        Ok(document::parse_markdown(relative_path, text))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Persisted state
+// ---------------------------------------------------------------------------
+
+/// Per-file state used for incremental re-indexing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileState {
+    /// mtime in seconds since the Unix epoch (0 when unavailable).
+    mtime: u64,
+    size: u64,
+    /// blake3 (first 8 bytes, LE) of the file content — catches edits that
+    /// preserve mtime/size.
+    hash: u64,
+}
+
+/// Persisted knowledge index metadata (`<knowledge_dir>/meta.json`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KnowledgeIndexMeta {
+    pub format_version: u32,
+    /// Per-file state keyed by project-relative path (forward slashes).
+    #[serde(default)]
+    pub files: HashMap<String, FileState>,
+}
+
+impl KnowledgeIndexMeta {
+    fn new() -> Self {
+        Self {
+            format_version: KNOWLEDGE_META_VERSION,
+            files: HashMap::new(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// In-memory index
+// ---------------------------------------------------------------------------
+
+/// In-memory knowledge index for one project.
+#[derive(Debug, Clone)]
+pub struct KnowledgeIndex {
+    /// Documents keyed by `doc_id` (`knowledge:<relative/path>`).
+    pub documents: HashMap<String, document::KnowledgeDocument>,
+    pub meta: KnowledgeIndexMeta,
+}
+
+impl Default for KnowledgeIndex {
+    fn default() -> Self {
+        Self {
+            documents: HashMap::new(),
+            meta: KnowledgeIndexMeta::new(),
+        }
+    }
+}
+
+/// Outcome of an incremental indexing run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IndexResult {
+    /// Documents (re)parsed this run.
+    pub parsed: usize,
+    /// Documents dropped because their file is gone or no longer eligible.
+    pub removed: usize,
+}
+
+impl IndexResult {
+    pub fn anything_changed(&self) -> bool {
+        self.parsed > 0 || self.removed > 0
+    }
+}
+
+impl KnowledgeIndex {
+    /// Load documents and metadata from `knowledge_dir` (empty when absent or
+    /// corrupt). A version mismatch starts fresh.
+    pub fn load(knowledge_dir: &Path) -> anyhow::Result<Self> {
+        let mut index = Self::default();
+
+        let docs_path = knowledge_dir.join("documents.bin");
+        if docs_path.exists() {
+            let bytes = std::fs::read(&docs_path)?;
+            match bincode::serde::decode_from_slice::<HashMap<String, document::KnowledgeDocument>, _>(
+                &bytes,
+                bincode::config::standard(),
+            ) {
+                Ok((documents, _)) => index.documents = documents,
+                Err(e) => tracing::warn!(
+                    path = %docs_path.display(),
+                    error = %e,
+                    "knowledge documents.bin corrupt — starting empty"
+                ),
+            }
+        }
+
+        let meta_path = knowledge_dir.join("meta.json");
+        if meta_path.exists() {
+            let bytes = std::fs::read(&meta_path)?;
+            match serde_json::from_slice::<KnowledgeIndexMeta>(&bytes) {
+                Ok(meta) if meta.format_version == KNOWLEDGE_META_VERSION => index.meta = meta,
+                Ok(_) => tracing::warn!(
+                    path = %meta_path.display(),
+                    "knowledge meta.json version mismatch — starting fresh"
+                ),
+                Err(e) => tracing::warn!(
+                    path = %meta_path.display(),
+                    error = %e,
+                    "knowledge meta.json corrupt — starting fresh"
+                ),
+            }
+        }
+
+        Ok(index)
+    }
+
+    /// Persist documents and metadata (atomic tmp+rename).
+    pub fn save(&self, knowledge_dir: &Path) -> anyhow::Result<()> {
+        std::fs::create_dir_all(knowledge_dir)?;
+        let bytes = bincode::serde::encode_to_vec(&self.documents, bincode::config::standard())?;
+        atomic_write(&knowledge_dir.join("documents.bin"), &bytes)?;
+        let meta = serde_json::to_vec_pretty(&self.meta)?;
+        atomic_write(&knowledge_dir.join("meta.json"), &meta)?;
+        Ok(())
+    }
+
+    /// Incrementally index all files handled by `source` under `root`.
+    ///
+    /// Files whose mtime and size match the persisted state are not re-read;
+    /// a content hash catches edits that preserve both. Unchanged documents
+    /// are kept in memory from the previous load.
+    pub fn index_project(
+        &mut self,
+        root: &Path,
+        source: &dyn ContentSource,
+    ) -> anyhow::Result<IndexResult> {
+        let exclude_set = build_knowledge_exclude_set(root)?;
+        let extra_dirs = extra_excluded_dir_names();
+        let extensions: HashSet<&str> = source.extensions().iter().copied().collect();
+
+        let mut current_files: HashMap<String, FileState> = HashMap::new();
+        let mut parsed = 0usize;
+
+        for entry in WalkDir::new(root)
+            .follow_links(false)
+            .into_iter()
+            .filter_entry(|entry| should_descend(root, &exclude_set, &extra_dirs, entry))
+        {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(err) => {
+                    crate::indexer::warn_walkdir_error(root, &err, "knowledge indexing");
+                    continue;
+                }
+            };
+            let path = entry.path();
+            if !entry.file_type().is_file() {
+                continue;
+            }
+            // regular_file_metadata rejects symlinks and non-regular files.
+            let Some(metadata) = regular_file_metadata(path)? else {
+                continue;
+            };
+            if metadata.len() > MAX_KNOWLEDGE_FILE_BYTES {
+                tracing::warn!(file = %path.display(), limit = MAX_KNOWLEDGE_FILE_BYTES, "skipping oversized knowledge file");
+                continue;
+            }
+            let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+            if !extensions.contains(ext) {
+                continue;
+            }
+            let rel = path.strip_prefix(root).unwrap_or(path);
+            let rel_str = rel.to_string_lossy().replace('\\', "/");
+            if exclude_set.is_match(rel_str.as_str()) || exclude_set.is_match(path) {
+                continue;
+            }
+
+            let mtime = mtime_secs(metadata.modified().ok());
+            let size = metadata.len();
+
+            // Fast path: mtime + size unchanged → keep the existing document.
+            if let Some(state) = self.meta.files.get(&rel_str) {
+                if state.mtime == mtime && state.size == size {
+                    current_files.insert(rel_str, state.clone());
+                    continue;
+                }
+            }
+
+            let bytes = read_regular_file(path)?;
+            let Ok(text) = std::str::from_utf8(&bytes) else {
+                tracing::warn!(file = %rel_str, "skipping non-UTF-8 knowledge file");
+                continue;
+            };
+            let hash = crate::embed::document::document_hash(text);
+
+            // Slow path: mtime/size drifted — the hash decides.
+            if let Some(state) = self.meta.files.get(&rel_str) {
+                if state.hash == hash {
+                    current_files.insert(rel_str, FileState { mtime, size, hash });
+                    continue;
+                }
+            }
+
+            match source.parse(&rel_str, text) {
+                Ok(doc) => {
+                    parsed += 1;
+                    self.documents.insert(doc.doc_id.clone(), doc);
+                }
+                Err(e) => {
+                    tracing::warn!(file = %rel_str, error = %e, "skipping unparseable knowledge file")
+                }
+            }
+            current_files.insert(rel_str, FileState { mtime, size, hash });
+        }
+
+        // Drop documents whose files are gone or no longer eligible.
+        let mut removed = 0usize;
+        self.documents.retain(|doc_id, _| {
+            let rel = doc_id.strip_prefix("knowledge:").unwrap_or(doc_id);
+            if current_files.contains_key(rel) {
+                return true;
+            }
+            removed += 1;
+            false
+        });
+
+        self.meta.files = current_files;
+        Ok(IndexResult { parsed, removed })
+    }
+}
+
+fn atomic_write(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
+    let tmp = path.with_extension("tmp");
+    let mut file = std::fs::File::create(&tmp)?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+fn mtime_secs(modified: Option<SystemTime>) -> u64 {
+    modified
+        .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Exclude set for knowledge walks: default patterns + `.gitignore` + saved
+/// per-project excludes (same policy as code search, owned here so the two
+/// indexers can evolve independently).
+fn build_knowledge_exclude_set(root: &Path) -> anyhow::Result<GlobSet> {
+    let mut builder = GlobSetBuilder::new();
+    for pattern in crate::indexer::default_exclude_patterns()
+        .into_iter()
+        .chain(crate::indexer::load_gitignore_patterns(root))
+        .chain(
+            crate::index::format::load_project_meta(root)
+                .map(|meta| meta.effective_excludes)
+                .unwrap_or_default(),
+        )
+    {
+        builder.add(Glob::new(&pattern)?);
+    }
+    Ok(builder.build()?)
+}
+
+/// Mirror of the code-index walk's descent filter: skip directories matched by
+/// the exclude set or named in the excluded-directory list.
+fn should_descend(
+    root: &Path,
+    exclude_set: &GlobSet,
+    extra_excluded_dirs: &HashSet<String>,
+    entry: &walkdir::DirEntry,
+) -> bool {
+    let path = entry.path();
+    let rel = match path.strip_prefix(root) {
+        Ok(rel) => rel,
+        Err(_) => return true,
+    };
+    if rel == Path::new("") {
+        return true;
+    }
+    let rel_str = rel.to_string_lossy();
+    if exclude_set.is_match(rel_str.as_ref()) {
+        return false;
+    }
+    if rel.components().any(|component| {
+        component.as_os_str().to_str().is_some_and(|name| {
+            crate::indexer::is_excluded_dir_name_with_custom(name, extra_excluded_dirs)
+        })
+    }) {
+        return false;
+    }
+    if entry.file_type().is_dir() && exclude_set.is_match(format!("{rel_str}/").as_str()) {
+        return false;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::knowledge::document::parse_markdown;
+    use std::fs::File;
+    use std::path::PathBuf;
+
+    fn temp_project(files: &[(&str, &str)]) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::TempDir::new().unwrap();
+        for (file, source) in files {
+            let path = dir.path().join(file);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, source).unwrap();
+        }
+        let canonical = dir.path().canonicalize().unwrap();
+        (dir, canonical)
+    }
+
+    #[test]
+    fn markdown_source_implements_trait() {
+        let source = MarkdownSource;
+        assert_eq!(source.name(), "markdown");
+        assert_eq!(source.extensions(), &["md", "markdown"]);
+        let doc = source.parse("a.md", "# T\nBody.\n").unwrap();
+        assert_eq!(doc.doc_id, "knowledge:a.md");
+        assert_eq!(parse_markdown("a.md", "# T\nBody.\n"), doc);
+    }
+
+    #[test]
+    fn index_project_discovers_and_filters_files() {
+        let (_dir, root) = temp_project(&[
+            ("docs/keep.md", "# Keep\nContent.\n"),
+            ("notes.markdown", "Preamble only.\n"),
+            ("node_modules/skip.md", "# Skip\n"),
+            ("large.md", &format!("# Large\n{}", "x".repeat(1024 * 1024))),
+            ("binary.md", ""),
+        ]);
+        std::fs::write(root.join("binary.md"), [0xff, 0xfe]).unwrap();
+
+        let mut index = KnowledgeIndex::default();
+        let result = index.index_project(&root, &MarkdownSource).unwrap();
+        assert_eq!(result.parsed, 2);
+        assert_eq!(result.removed, 0);
+        assert!(index.documents.contains_key("knowledge:docs/keep.md"));
+        assert!(index.documents.contains_key("knowledge:notes.markdown"));
+        assert!(!index.documents.keys().any(|k| k.contains("skip")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinks_are_not_followed() {
+        let (_dir, root) = temp_project(&[("keep.md", "# Keep\n")]);
+        let outside = tempfile::TempDir::new().unwrap();
+        std::fs::write(outside.path().join("outside.md"), "# Outside\n").unwrap();
+        std::os::unix::fs::symlink(outside.path().join("outside.md"), root.join("link.md"))
+            .unwrap();
+
+        let mut index = KnowledgeIndex::default();
+        let result = index.index_project(&root, &MarkdownSource).unwrap();
+        assert_eq!(result.parsed, 1);
+        assert!(!index.documents.keys().any(|k| k.contains("link")));
+    }
+
+    #[test]
+    fn incremental_reindex_skips_unchanged_files() {
+        let (_dir, root) = temp_project(&[("a.md", "# A\nOne.\n"), ("b.md", "# B\nTwo.\n")]);
+
+        let mut index = KnowledgeIndex::default();
+        assert_eq!(
+            index.index_project(&root, &MarkdownSource).unwrap(),
+            IndexResult {
+                parsed: 2,
+                removed: 0
+            }
+        );
+
+        // Second run: nothing changed.
+        let result = index.index_project(&root, &MarkdownSource).unwrap();
+        assert_eq!(
+            result,
+            IndexResult {
+                parsed: 0,
+                removed: 0
+            }
+        );
+
+        // Modify one file → only it is reparsed.
+        std::fs::write(root.join("a.md"), "# A\nOne, updated.\n").unwrap();
+        let result = index.index_project(&root, &MarkdownSource).unwrap();
+        assert_eq!(result.parsed, 1);
+        assert!(index.documents["knowledge:a.md"]
+            .sections
+            .iter()
+            .any(|s| s.content.contains("updated")));
+
+        // Delete a file → its document is removed.
+        std::fs::remove_file(root.join("b.md")).unwrap();
+        let result = index.index_project(&root, &MarkdownSource).unwrap();
+        assert_eq!(result.removed, 1);
+        assert!(!index.documents.contains_key("knowledge:b.md"));
+    }
+
+    #[test]
+    fn same_mtime_edit_is_caught_by_hash() {
+        let (_dir, root) = temp_project(&[("a.md", "# A\nOriginal.\n")]);
+
+        let mut index = KnowledgeIndex::default();
+        index.index_project(&root, &MarkdownSource).unwrap();
+
+        // Edit content, then restore the original mtime so only the hash can
+        // detect the change.
+        let path = root.join("a.md");
+        let old_mtime = File::open(&path)
+            .unwrap()
+            .metadata()
+            .unwrap()
+            .modified()
+            .unwrap();
+        std::fs::write(&path, "# A\nEdited.\n").unwrap();
+        File::open(&path).unwrap().set_modified(old_mtime).unwrap();
+
+        let result = index.index_project(&root, &MarkdownSource).unwrap();
+        assert_eq!(result.parsed, 1);
+        assert!(index.documents["knowledge:a.md"]
+            .sections
+            .iter()
+            .any(|s| s.content.contains("Edited")));
+    }
+
+    #[test]
+    fn save_and_load_round_trip() {
+        let (_dir, root) = temp_project(&[("docs/a.md", "# A\nBody.\n")]);
+        let knowledge_dir = tempfile::tempdir().unwrap();
+
+        let mut index = KnowledgeIndex::default();
+        index.index_project(&root, &MarkdownSource).unwrap();
+        index.save(knowledge_dir.path()).unwrap();
+
+        let loaded = KnowledgeIndex::load(knowledge_dir.path()).unwrap();
+        assert_eq!(loaded.documents, index.documents);
+        assert_eq!(loaded.meta.files.len(), 1);
+    }
+
+    #[test]
+    fn load_missing_or_corrupt_dir_returns_empty() {
+        let missing = tempfile::tempdir().unwrap();
+        let index = KnowledgeIndex::load(missing.path()).unwrap();
+        assert!(index.documents.is_empty());
+
+        let corrupt = tempfile::tempdir().unwrap();
+        std::fs::write(corrupt.path().join("documents.bin"), b"not bincode").unwrap();
+        std::fs::write(corrupt.path().join("meta.json"), b"{no json").unwrap();
+        let index = KnowledgeIndex::load(corrupt.path()).unwrap();
+        assert!(index.documents.is_empty());
+        assert_eq!(index.meta.format_version, KNOWLEDGE_META_VERSION);
+    }
+
+    #[test]
+    fn gitignore_and_saved_excludes_are_respected() {
+        let (dir, root) = temp_project(&[
+            ("visible.md", "# Visible\n"),
+            ("hidden/secret.md", "# Secret\n"),
+            ("skipped.md", "# Skipped\n"),
+        ]);
+        std::fs::write(dir.path().join(".gitignore"), "hidden/\n").unwrap();
+
+        let mut meta = crate::index::format::IndexMeta::new(&root);
+        meta.effective_excludes = vec!["skipped.md".into()];
+        let idx_dir = crate::index::format::index_dir(&root).unwrap();
+        std::fs::create_dir_all(&idx_dir).unwrap();
+        crate::index::format::save_meta(&meta, &idx_dir.join("meta.json")).unwrap();
+
+        let mut index = KnowledgeIndex::default();
+        let result = index.index_project(&root, &MarkdownSource).unwrap();
+        assert_eq!(result.parsed, 1);
+        assert!(index.documents.contains_key("knowledge:visible.md"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod graph;
 pub mod index;
 pub mod indexer;
 pub mod indexing;
+pub mod knowledge;
 pub mod path_policy;
 pub mod session;
 pub mod stats;

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,6 +171,7 @@ project_field!(
     FindCallersRequest => canonical = "project", alias = "path";
     FindUsagesRequest => canonical = "project", alias = "path";
     WatchProjectRequest => canonical = "project", alias = "path";
+    SearchKnowledgeRequest => canonical = "project", alias = "path";
     GetIndexStatsRequest => canonical = "project", alias = "path";
     DoctorRequest => canonical = "project", alias = "path";
     GetIndexChangesRequest => canonical = "project", alias = "path";
@@ -212,6 +213,21 @@ pub struct IndexProjectRequest {
     /// Maximum number of source files to index (default: 100 000). Raise for very large
     /// mono-repos. Omit this field, or set it to 0, to use the default.
     pub max_files: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct SearchKnowledgeRequest {
+    /// Path to an indexed project. The MCP field `path` is accepted as an alias.
+    #[serde(alias = "path")]
+    pub project: String,
+    /// Natural-language query describing the information need (e.g., "how does retry with backoff work").
+    pub query: String,
+    /// Optional document-level tag filter from front matter (`tags`/`categories`). Case-insensitive.
+    pub tag: Option<String>,
+    /// Optional substring filter on relative file paths (e.g., "docs/runbooks").
+    pub path_filter: Option<String>,
+    /// Maximum number of sections to return (default 8, max 50).
+    pub limit: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
@@ -999,6 +1015,34 @@ impl PitlaneMcp {
             max_depth: req.max_depth,
         };
         match tools::orchestrator::trace_path(params).await {
+            Ok(v) => value_to_text(v),
+            Err(e) => err_to_text(e),
+        }
+    }
+
+    #[tool(
+        description = "Search the project's Markdown knowledge base (docs/README/runbooks) by heading and content with lexical + semantic ranking when embeddings exist. Prefer this for documentation questions; use read_code_unit on a result to open the full section.",
+        meta = tool_meta("search docs documentation markdown knowledge readme runbook"),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn search_knowledge(
+        &self,
+        Parameters(Friendly(req)): Parameters<Friendly<SearchKnowledgeRequest>>,
+    ) -> String {
+        let params = tools::search_knowledge::SearchKnowledgeParams {
+            project: req.project,
+            query: req.query,
+            tag: req.tag,
+            path_filter: req.path_filter,
+            limit: req.limit,
+            embed_config: self.embed_config.clone(),
+        };
+        match tools::search_knowledge::search_knowledge(params).await {
             Ok(v) => value_to_text(v),
             Err(e) => err_to_text(e),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -629,6 +629,7 @@ const DEFAULT_PUBLIC_TOOL_NAMES: &[&str] = &[
     "get_index_stats",
     "doctor",
     "search_content",
+    "search_knowledge",
 ];
 
 const ADVANCED_TOOL_NAMES: &[&str] = &[

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -17,6 +17,7 @@ pub mod investigate;
 pub mod orchestrator;
 pub mod search_content;
 pub mod search_files;
+pub mod search_knowledge;
 pub mod search_symbols;
 pub mod semantic_rank;
 pub mod steering;

--- a/src/tools/search_knowledge.rs
+++ b/src/tools/search_knowledge.rs
@@ -142,7 +142,7 @@ pub async fn search_knowledge(params: SearchKnowledgeParams) -> anyhow::Result<V
         let Some(scan_store) = store.as_ref() else {
             return Ok(empty_response(&index, &params.query));
         };
-        for (id, _vec) in scan_store.vectors.iter() {
+        for id in scan_store.vectors.keys() {
             if let Some(cand) = resolve_candidate(&index, id, params.tag.as_deref())
                 .filter(|c| path_matches(params.path_filter.as_deref(), &c.file_path))
             {

--- a/src/tools/search_knowledge.rs
+++ b/src/tools/search_knowledge.rs
@@ -1,0 +1,590 @@
+//! Knowledge-base search over indexed Markdown documents (Phase 1 of #118).
+//!
+//! Hybrid ranking: lexical BM25 over sections plus semantic cosine similarity
+//! when an embedding store exists. Falls back to pure-semantic top-k across all
+//! embedded sections when the query has no lexical matches at all.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, LazyLock, RwLock};
+
+use serde_json::{json, Value};
+
+use crate::embed::client::{cosine_similarity, EmbedClient};
+use crate::embed::store::{EmbedStore, EmbedStoreMetadata};
+use crate::embed::EmbedConfig;
+use crate::error::ToolError;
+use crate::index::format::knowledge_dir;
+use crate::knowledge::{document, ensure_knowledge_index, generate_knowledge_embeddings};
+use crate::path_policy::resolve_project_path;
+use crate::tools::steering::{attach_steering, build_steering};
+
+const DEFAULT_LIMIT: usize = 8;
+const MAX_LIMIT: usize = 50;
+/// Lexical candidates fetched before hybrid re-ranking.
+fn candidate_fetch(limit: usize) -> usize {
+    (limit * 4).clamp(60, 300)
+}
+/// Snippet length in characters for search results.
+const SNIPPET_CHARS: usize = 320;
+
+pub struct SearchKnowledgeParams {
+    pub project: String,
+    /// Natural-language query describing the information need.
+    pub query: String,
+    /// Optional document-level tag filter (front matter `tags`/`categories`).
+    pub tag: Option<String>,
+    /// Optional substring filter on the relative file path.
+    pub path_filter: Option<String>,
+    pub limit: Option<usize>,
+    pub embed_config: Option<Arc<EmbedConfig>>,
+}
+
+/// One ranked result section with its score breakdown.
+struct Candidate {
+    full_section_id: String,
+    file_path: String,
+    doc_title: String,
+    tags: Vec<String>,
+    heading: String,
+    line_start: usize,
+    line_end: usize,
+    snippet: String,
+    bm25_score: Option<f32>,
+}
+
+pub async fn search_knowledge(params: SearchKnowledgeParams) -> anyhow::Result<Value> {
+    if params.query.trim().is_empty() {
+        return Err(ToolError::InvalidArgument {
+            param: "query".to_string(),
+            message: "query must not be empty".to_string(),
+        }
+        .into());
+    }
+
+    let canonical = resolve_project_path(&params.project)?;
+    // Incremental indexing may walk many files — keep it off the async runtime.
+    let root_for_blocking = canonical.clone();
+    let (changed, index) =
+        tokio::task::spawn_blocking(move || ensure_knowledge_index(&root_for_blocking))
+            .await
+            .map_err(|e| anyhow::anyhow!("knowledge indexing task failed: {e}"))??;
+
+    if changed && !index.documents.is_empty() {
+        tracing::info!(
+            docs = index.documents.len(),
+            "search_knowledge: knowledge documents updated"
+        );
+    }
+
+    // Kick off background embedding generation when configured and the store
+    // is missing or stale. Deduped per project so concurrent searches do not
+    // double-spawn; steady-state requests with a fresh store never spawn.
+    maybe_spawn_knowledge_embeds(&canonical, &index, changed, params.embed_config.clone());
+
+    let limit = params.limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT);
+    let kdir = knowledge_dir(&canonical)?;
+
+    // ── Lexical candidates (BM25 over sections) ────────────────────────────
+    let fetch = candidate_fetch(limit);
+    let hits = crate::index::knowledge_bm25::search(
+        &params.query,
+        &canonical,
+        &kdir.join("tantivy"),
+        fetch,
+    )?;
+
+    let mut candidates: Vec<Candidate> = Vec::new();
+    for hit in &hits {
+        if let Some(mut cand) =
+            resolve_candidate(&index, hit.section_id.as_str(), params.tag.as_deref())
+                .filter(|c| path_matches(params.path_filter.as_deref(), &c.file_path))
+        {
+            cand.bm25_score = Some(hit.score);
+            candidates.push(cand);
+        }
+    }
+
+    // ── Semantic availability (non-fatal: lexical still works) ─────────────
+    let store_path = kdir.join("embeddings.bin");
+    let mut query_vec: Option<Vec<f32>> = None;
+    let mut store: Option<EmbedStore> = None;
+    if let Some(cfg) = params.embed_config.clone() {
+        if let Some(compatible_store) = load_compatible_store(&store_path, &cfg) {
+            match tokio::time::timeout(
+                std::time::Duration::from_millis(query_timeout_ms()),
+                EmbedClient::new(Arc::clone(&cfg)).embed_query(&params.query),
+            )
+            .await
+            {
+                Ok(Ok(vec)) => {
+                    query_vec = Some(vec);
+                    store = Some(compatible_store);
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        "search_knowledge: semantic scoring disabled (query embedding timed out)"
+                    );
+                }
+                Ok(Err(e)) => {
+                    tracing::warn!(error = %e, "search_knowledge: semantic scoring disabled ({e})");
+                }
+            }
+        }
+    }
+
+    // ── Scoring ─────────────────────────────────────────────────────────────
+    if candidates.is_empty() {
+        // Pure-semantic fallback: rank every embedded section.
+        let Some(scan_store) = store.as_ref() else {
+            return Ok(empty_response(&index, &params.query));
+        };
+        for (id, _vec) in scan_store.vectors.iter() {
+            if let Some(cand) = resolve_candidate(&index, id, params.tag.as_deref())
+                .filter(|c| path_matches(params.path_filter.as_deref(), &c.file_path))
+            {
+                candidates.push(cand);
+            }
+        }
+    }
+
+    let sem_weight = semantic_weight();
+    // Hybrid: weighted blend of cosine similarity and max-normalized BM25.
+    // Without a query vector we keep the lexical ranking as-is.
+    let scored: Vec<(f64, Candidate)> = if let Some(qv) = query_vec.as_ref() {
+        let max_bm25 = candidates
+            .iter()
+            .filter_map(|c| c.bm25_score)
+            .fold(0.0_f32, f32::max);
+        let mut out: Vec<(f64, Candidate)> = Vec::new();
+        for cand in std::mem::take(&mut candidates) {
+            let sim = store
+                .as_ref()
+                .and_then(|s| s.vectors.get(&cand.full_section_id))
+                .filter(|v| v.len() == qv.len())
+                .map(|v| cosine_similarity(qv, v));
+            let lexical = cand
+                .bm25_score
+                .map(|s| max_bm25.max(f32::EPSILON).recip() * s);
+            let score: f32 = match (sim, lexical) {
+                (Some(s), Some(l)) => sem_weight * s + (1.0 - sem_weight) * l,
+                (Some(s), None) => s,
+                (_, Some(l)) => l,
+                (None, None) => 0.0,
+            };
+            out.push((round_frac3(f64::from(score)), cand));
+        }
+        out.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+        out.truncate(limit);
+        out
+    } else {
+        // No semantic signal: keep BM25 order (already ranked).
+        std::mem::take(&mut candidates)
+            .into_iter()
+            .map(|c| (round_frac3(f64::from(c.bm25_score.unwrap_or(0.0))), c))
+            .collect::<Vec<_>>()
+    };
+
+    // ── Response ────────────────────────────────────────────────────────────
+    let total_sections: usize = index.documents.values().map(|d| d.sections.len()).sum();
+    let embeddings_used =
+        query_vec.is_some() && store.as_ref().is_some_and(|s| !s.vectors.is_empty());
+
+    let results: Vec<Value> = scored
+        .into_iter()
+        .map(|(score, c)| {
+            json!({
+                "section_id": c.full_section_id,
+                "file_path": c.file_path,
+                "doc_title": c.doc_title,
+                "heading": c.heading,
+                "line_start": c.line_start,
+                "line_end": c.line_end,
+                "tags": if c.tags.is_empty() { Value::Null } else { json!(c.tags) },
+                "snippet": c.snippet,
+                "score": score,
+            })
+        })
+        .collect();
+
+    let mut response = json!({
+        "query": params.query,
+        "total_sections": total_sections,
+        "results_count": results.len(),
+        "embeddings_used": embeddings_used,
+        "results": results,
+        "guidance": {
+            "next_step": if results.is_empty() {
+                "No knowledge sections matched. Try a broader query or check that Markdown files exist in the project (they must not be gitignored)."
+            } else {
+                "Use read_code_unit with file_path and line_start/line_end to open the full section, then follow links in neighboring docs."
+            },
+            "avoid": "Avoid loading whole documentation trees into context; fetch sections on demand.",
+        },
+    });
+
+    let top = results.first();
+    let steering = build_steering(
+        if results.is_empty() { 0.2 } else { 0.85 },
+        if results.is_empty() {
+            "No knowledge section matched the query.".to_string()
+        } else {
+            format!(
+                "Top result scores {} on the combined lexical/semantic ranking.",
+                top.as_ref()
+                    .and_then(|r| r["score"].as_f64())
+                    .unwrap_or(0.0)
+            )
+        },
+        if results.is_empty() {
+            "search_content"
+        } else {
+            "read_code_unit"
+        },
+        match &top {
+            Some(r) => json!({
+                "file_path": r["file_path"],
+                "line_start": r["line_start"],
+                "line_end": r["line_end"],
+            }),
+            None => json!(params.project),
+        },
+        Vec::new(),
+    );
+    attach_steering(&mut response, steering);
+    Ok(response)
+}
+
+/// Resolve a `knowledge:<path>#<slug>` ID to its section payload.
+fn resolve_candidate(
+    index: &crate::knowledge::KnowledgeIndex,
+    full_id: &str,
+    tag_filter: Option<&str>,
+) -> Option<Candidate> {
+    let (doc_id, slug) = full_id.split_once('#')?;
+    let doc = index.documents.get(doc_id)?;
+    if let Some(tag) = tag_filter.filter(|t| !t.trim().is_empty()) {
+        if !matches_tag(&doc.tags, tag) {
+            return None;
+        }
+    }
+    let section = doc.sections.iter().find(|s| s.section_id == slug)?.clone();
+    Some(Candidate {
+        full_section_id: full_id.to_string(),
+        file_path: doc.file_path.clone(),
+        doc_title: doc.title.clone(),
+        tags: if doc.tags.is_empty() {
+            Vec::new()
+        } else {
+            doc.tags.clone()
+        },
+        heading: section_heading(&section),
+        line_start: section.line_start,
+        line_end: section.line_end,
+        snippet: make_snippet(&section.content),
+        bm25_score: None,
+    })
+}
+
+fn matches_tag(tags: &[String], tag: &str) -> bool {
+    tags.iter().any(|t| t.eq_ignore_ascii_case(tag))
+}
+
+/// Substring match on the relative file path; `None` filter passes everything.
+fn path_matches(filter: Option<&str>, path: &str) -> bool {
+    filter.is_none_or(|f| f.trim().is_empty() || path.contains(f))
+}
+
+fn section_heading(section: &document::KnowledgeSection) -> String {
+    if section.hierarchy.is_empty() {
+        "(preamble)".to_string()
+    } else {
+        section.hierarchy.join(" > ")
+    }
+}
+
+/// Compact one-paragraph preview of a section body.
+fn make_snippet(content: &str) -> String {
+    let collapsed = content
+        .split('\n')
+        .filter(|l| !l.trim().is_empty())
+        .collect::<Vec<_>>();
+    let joined = if collapsed.is_empty() {
+        String::new()
+    } else {
+        // Skip leading Markdown heading lines; keep body text.
+        collapsed
+            .iter()
+            .skip_while(|line| line.starts_with('#'))
+            .copied()
+            .collect::<Vec<_>>()
+            .join(" ")
+    };
+    let joined = joined.trim().to_string();
+    if joined.len() <= SNIPPET_CHARS {
+        return joined;
+    }
+    // Cut on a word boundary at or before the limit.
+    let mut end = SNIPPET_CHARS.min(joined.len());
+    while !joined.is_char_boundary(end) {
+        if end == 0 {
+            break;
+        }
+        end -= 1;
+    }
+    // Prefer a word boundary within the limit.
+    let cut_end = joined[..end].trim_end().len();
+    format!("{}…", &joined[..cut_end])
+}
+
+/// Response shape for "nothing matched at all" (no lexical hits and no
+/// usable semantic store).
+fn empty_response(index: &crate::knowledge::KnowledgeIndex, query: &str) -> Value {
+    let total_sections: usize = index.documents.values().map(|d| d.sections.len()).sum();
+    let mut response = json!({
+        "query": query,
+        "total_sections": total_sections,
+        "results_count": 0usize,
+        "embeddings_used": false,
+        "results": [],
+        "guidance": {
+            "next_step": if total_sections == 0 {
+                "No Markdown documents are indexed for this project yet. Add .md files (not gitignored) and re-run ensure_project_ready, or use search_content to find text directly in source files."
+            } else {
+                "No knowledge sections matched. Try a broader query with fewer terms; headings match strongly, so naming the likely heading helps."
+            },
+            "avoid": "Avoid loading whole documentation trees into context; fetch sections on demand.",
+        },
+    });
+    let steering = build_steering(
+        0.2,
+        if total_sections == 0 {
+            "The project has no indexed knowledge documents.".to_string()
+        } else {
+            "No knowledge section matched the query".to_string()
+        },
+        "search_content",
+        json!({}),
+        Vec::new(),
+    );
+    attach_steering(&mut response, steering);
+    response
+}
+
+// Projects whose background knowledge-embedding task is currently running.
+static EMBED_INFLIGHT: LazyLock<RwLock<HashSet<PathBuf>>> =
+    LazyLock::new(|| RwLock::new(HashSet::new()));
+
+/// Spawn a detached task that (re)generates section embeddings when the store
+/// is missing, incompatible with the configured model/endpoint, or dirty.
+pub(crate) fn maybe_spawn_knowledge_embeds(
+    canonical: &Path,
+    index: &crate::knowledge::KnowledgeIndex,
+    dirty: bool,
+    embed_config: Option<Arc<EmbedConfig>>,
+) {
+    let Some(cfg) = embed_config else { return };
+    let expected = index
+        .documents
+        .values()
+        .flat_map(|d| d.sections.iter())
+        .filter(|s| !s.is_empty())
+        .count();
+    if expected == 0 {
+        return;
+    }
+
+    let store_path = match knowledge_dir(canonical) {
+        Ok(kdir) => kdir.join("embeddings.bin"),
+        Err(_) => return,
+    };
+    let fresh = EmbedStoreMetadata::load(&store_path)
+        .ok()
+        .flatten()
+        .is_some_and(|m| {
+            m.is_compatible(
+                &cfg.model,
+                &crate::embed::document::document_fingerprint(&cfg.model),
+                &crate::embed::endpoint_fingerprint(&cfg.url, &cfg.headers),
+            ) && m.dimension > 0
+        });
+    if !dirty && fresh {
+        return;
+    }
+
+    if let Some(parent) = store_path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+
+    let key = canonical.to_path_buf();
+    {
+        let mut inflight = crate::sync_utils::rw_write(&EMBED_INFLIGHT);
+        if !inflight.insert(key.clone()) {
+            return; // already running for this project
+        }
+    }
+
+    // Clone only on the (rare) spawn path — steady-state requests skip here.
+    let docs_owned: Vec<document::KnowledgeDocument> = index.documents.values().cloned().collect();
+    tokio::spawn(async move {
+        let result = generate_knowledge_embeddings(&docs_owned, &cfg, &store_path).await;
+        crate::sync_utils::rw_write(&EMBED_INFLIGHT).remove(&key);
+        if let Some(err) = result.error {
+            tracing::error!(project = %key.display(), error = %err, "knowledge-embed: background generation failed");
+        } else {
+            tracing::info!(stored = result.stored, skipped = result.skipped, elapsed_ms = result.elapsed_ms, project = %key.display(), "knowledge-embed: background generation complete");
+        }
+    });
+}
+
+/// Load the embedding store only when its metadata is compatible with `cfg`.
+fn load_compatible_store(store_path: &std::path::Path, cfg: &EmbedConfig) -> Option<EmbedStore> {
+    let store = EmbedStore::load(store_path).ok()?;
+    if store.vectors.is_empty() {
+        return None;
+    }
+    let meta = EmbedStoreMetadata::load(store_path).ok().flatten()?;
+    meta.is_compatible(
+        &cfg.model,
+        &crate::embed::document::document_fingerprint(&cfg.model),
+        &crate::embed::endpoint_fingerprint(&cfg.url, &cfg.headers),
+    )
+    .then_some(store)
+}
+
+fn semantic_weight() -> f32 {
+    std::env::var("PITLANE_KNOWLEDGE_SEMANTIC_WEIGHT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|w: &f32| w.is_finite() && *w >= 0.0 && *w <= 1.0)
+        .unwrap_or(0.7)
+}
+
+fn query_timeout_ms() -> u64 {
+    std::env::var("PITLANE_SEMANTIC_QUERY_TIMEOUT_MS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|ms: &u64| *ms > 0)
+        .unwrap_or(15_000)
+}
+
+fn round_frac3(v: f64) -> f64 {
+    (v * 1000.0).round() / 1000.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::header::HeaderMap;
+    use tempfile::TempDir;
+
+    #[test]
+    fn snippet_collapses_and_truncates_on_word_boundary() {
+        let text = "# Title\nFirst line.\nSecond line.";
+        assert_eq!(make_snippet(text), "First line. Second line.");
+
+        let long = "word ".repeat(100);
+        let out = make_snippet(&long);
+        // Content ≤ limit bytes plus the ellipsis (3 UTF-8 bytes).
+        let content_len = out.chars().count();
+        assert!(content_len <= SNIPPET_CHARS + 1, "{content_len}");
+        assert!(out.ends_with('…'));
+
+        // Empty content → empty snippet.
+        assert_eq!(make_snippet(""), "");
+    }
+
+    #[test]
+    fn tag_and_path_filters_behave_as_documented() {
+        let mut index = crate::knowledge::KnowledgeIndex::default();
+        let doc = document::parse_markdown(
+            "docs/a.md",
+            "---\ntags: [ops]\n---\n# A\nBody here.\n## Sub\nMore body.\n",
+        );
+        index.documents.insert(doc.doc_id.clone(), doc);
+
+        let hit = resolve_candidate(&index, "knowledge:docs/a.md#a-sub", Some("OPS"));
+        assert!(hit.is_some());
+        assert!(resolve_candidate(&index, "knowledge:docs/a.md#a-sub", Some("dev")).is_none());
+    }
+
+    #[tokio::test]
+    async fn background_embeds_spawn_when_dirty_and_dedupe() {
+        use httpmock::prelude::*;
+
+        let root = TempDir::new().unwrap();
+        let canonical = root.path().canonicalize().unwrap();
+
+        // One document with one non-empty section.
+        let doc = document::parse_markdown("a.md", "# A\nBody.\n");
+        let mut index = crate::knowledge::KnowledgeIndex::default();
+        index.documents.insert(doc.doc_id.clone(), doc);
+
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(json!({"data": [{"index": 0, "embedding": [1.0]}]}).to_string());
+        });
+
+        let cfg = Arc::new(EmbedConfig {
+            url: server.url("/"),
+            model: "test".into(),
+            headers: HeaderMap::new(),
+        });
+
+        maybe_spawn_knowledge_embeds(&canonical, &index, true, Some(Arc::clone(&cfg)));
+
+        // Poll until the background task persisted a vector (≤10 s).
+        let store_path = crate::index::format::knowledge_dir(&canonical)
+            .unwrap()
+            .join("embeddings.bin");
+        for _ in 0..1_000 {
+            if EmbedStore::load(&store_path)
+                .ok()
+                .is_some_and(|s| !s.vectors.is_empty())
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        let store = EmbedStore::load(&store_path).expect("embeddings.bin written");
+        assert!(!store.vectors.is_empty());
+
+        // A follow-up call with the store now fresh and !dirty must be a no-op
+        // (no new task); it still returns cleanly either way.
+        maybe_spawn_knowledge_embeds(&canonical, &index, false, Some(cfg));
+    }
+
+    #[tokio::test]
+    async fn search_knowledge_ranks_lexical_hits() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join("docs")).unwrap();
+        std::fs::write(
+            dir.path().join("docs/retry.md"),
+            "# Retry policy\nThe client retries failed requests with exponential backoff.\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("README.md"),
+            "# Project readme\nThis project is a test fixture for knowledge search.\n",
+        )
+        .unwrap();
+
+        let root = dir.path().canonicalize().unwrap();
+        let params = SearchKnowledgeParams {
+            project: root.to_string_lossy().to_string(),
+            query: "retry backoff policy".into(),
+            tag: None,
+            path_filter: Some("docs/".to_string()),
+            limit: Some(5),
+            embed_config: None,
+        };
+        let response = search_knowledge(params).await.unwrap();
+
+        assert_eq!(response["results_count"], 1);
+        assert_eq!(response["results"][0]["file_path"], "docs/retry.md");
+        // README is excluded by the path filter even though it matches lexically.
+    }
+}

--- a/src/tools/search_knowledge.rs
+++ b/src/tools/search_knowledge.rs
@@ -15,7 +15,7 @@ use crate::embed::store::{EmbedStore, EmbedStoreMetadata};
 use crate::embed::EmbedConfig;
 use crate::error::ToolError;
 use crate::index::format::knowledge_dir;
-use crate::knowledge::{document, ensure_knowledge_index, generate_knowledge_embeddings};
+use crate::knowledge::{document, generate_knowledge_embeddings, with_knowledge_index};
 use crate::path_policy::resolve_project_path;
 use crate::tools::steering::{attach_steering, build_steering};
 
@@ -63,12 +63,24 @@ pub async fn search_knowledge(params: SearchKnowledgeParams) -> anyhow::Result<V
     }
 
     let canonical = resolve_project_path(&params.project)?;
+    let limit = params.limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT);
+    let fetch = candidate_fetch(limit);
     // Incremental indexing may walk many files — keep it off the async runtime.
     let root_for_blocking = canonical.clone();
-    let (changed, index) =
-        tokio::task::spawn_blocking(move || ensure_knowledge_index(&root_for_blocking))
-            .await
-            .map_err(|e| anyhow::anyhow!("knowledge indexing task failed: {e}"))??;
+    let query = params.query.clone();
+    let (changed, index, hits) = tokio::task::spawn_blocking(move || {
+        with_knowledge_index(&root_for_blocking, |changed, index| {
+            let hits = crate::index::knowledge_bm25::search(
+                &query,
+                &root_for_blocking,
+                &knowledge_dir(&root_for_blocking)?.join("tantivy"),
+                fetch,
+            )?;
+            Ok((changed, index, hits))
+        })
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("knowledge indexing task failed: {e}"))??;
 
     if changed && !index.documents.is_empty() {
         tracing::info!(
@@ -82,18 +94,9 @@ pub async fn search_knowledge(params: SearchKnowledgeParams) -> anyhow::Result<V
     // double-spawn; steady-state requests with a fresh store never spawn.
     maybe_spawn_knowledge_embeds(&canonical, &index, changed, params.embed_config.clone());
 
-    let limit = params.limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT);
     let kdir = knowledge_dir(&canonical)?;
 
     // ── Lexical candidates (BM25 over sections) ────────────────────────────
-    let fetch = candidate_fetch(limit);
-    let hits = crate::index::knowledge_bm25::search(
-        &params.query,
-        &canonical,
-        &kdir.join("tantivy"),
-        fetch,
-    )?;
-
     let mut candidates: Vec<Candidate> = Vec::new();
     for hit in &hits {
         if let Some(mut cand) =
@@ -181,6 +184,7 @@ pub async fn search_knowledge(params: SearchKnowledgeParams) -> anyhow::Result<V
         // No semantic signal: keep BM25 order (already ranked).
         std::mem::take(&mut candidates)
             .into_iter()
+            .take(limit)
             .map(|c| (round_frac3(f64::from(c.bm25_score.unwrap_or(0.0))), c))
             .collect::<Vec<_>>()
     };
@@ -398,16 +402,8 @@ pub(crate) fn maybe_spawn_knowledge_embeds(
         Ok(kdir) => kdir.join("embeddings.bin"),
         Err(_) => return,
     };
-    let fresh = EmbedStoreMetadata::load(&store_path)
-        .ok()
-        .flatten()
-        .is_some_and(|m| {
-            m.is_compatible(
-                &cfg.model,
-                &crate::embed::document::document_fingerprint(&cfg.model),
-                &crate::embed::endpoint_fingerprint(&cfg.url, &cfg.headers),
-            ) && m.dimension > 0
-        });
+    let fresh = load_compatible_store(&store_path, &cfg)
+        .is_some_and(|store| knowledge_embeddings_complete(index, &store));
     if !dirty && fresh {
         return;
     }
@@ -435,6 +431,25 @@ pub(crate) fn maybe_spawn_knowledge_embeds(
             tracing::info!(stored = result.stored, skipped = result.skipped, elapsed_ms = result.elapsed_ms, project = %key.display(), "knowledge-embed: background generation complete");
         }
     });
+}
+
+fn knowledge_embeddings_complete(
+    index: &crate::knowledge::KnowledgeIndex,
+    store: &EmbedStore,
+) -> bool {
+    index.documents.values().all(|doc| {
+        doc.sections
+            .iter()
+            .filter(|s| !s.is_empty())
+            .all(|section| {
+                let id = section.full_id(&doc.doc_id);
+                store.vectors.get(&id).is_some_and(|v| !v.is_empty())
+                    && store.hashes.get(&id)
+                        == Some(&crate::embed::document::document_hash(
+                            &section.embedding_text(doc),
+                        ))
+            })
+    })
 }
 
 /// Load the embedding store only when its metadata is compatible with `cfg`.
@@ -586,5 +601,63 @@ mod tests {
         assert_eq!(response["results_count"], 1);
         assert_eq!(response["results"][0]["file_path"], "docs/retry.md");
         // README is excluded by the path filter even though it matches lexically.
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_searches_respect_limits_after_edits() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("docs.md");
+        for version in ["original", "modified"] {
+            std::fs::write(
+                &path,
+                (0..70)
+                    .map(|i| format!("# Retry {i}\nRetry {version} body.\n"))
+                    .collect::<String>(),
+            )
+            .unwrap();
+            let mut tasks = Vec::new();
+            for limit in [0, 1, 8, 50, 100, 1, 8, 50] {
+                let project = dir.path().to_string_lossy().to_string();
+                tasks.push(tokio::spawn(async move {
+                    let response = search_knowledge(SearchKnowledgeParams {
+                        project,
+                        query: "retry".into(),
+                        tag: None,
+                        path_filter: None,
+                        limit: Some(limit),
+                        embed_config: None,
+                    })
+                    .await
+                    .unwrap();
+                    assert_eq!(response["results_count"], limit.min(50));
+                    for result in response["results"].as_array().unwrap() {
+                        assert!(result["snippet"].as_str().unwrap().contains(version));
+                    }
+                }));
+            }
+            for task in tasks {
+                task.await.unwrap();
+            }
+        }
+    }
+
+    #[test]
+    fn embedding_completeness_detects_partial_and_outdated_stores() {
+        let doc = document::parse_markdown("a.md", "# A\nOne.\n## B\nTwo.\n");
+        let mut index = crate::knowledge::KnowledgeIndex::default();
+        index.documents.insert(doc.doc_id.clone(), doc.clone());
+        let mut store = EmbedStore::new();
+        for section in &doc.sections {
+            assert!(!knowledge_embeddings_complete(&index, &store));
+            let id = section.full_id(&doc.doc_id);
+            store.update(id.clone(), vec![1.0]);
+            store.hashes.insert(
+                id,
+                crate::embed::document::document_hash(&section.embedding_text(&doc)),
+            );
+        }
+        assert!(knowledge_embeddings_complete(&index, &store));
+        index.documents.get_mut(&doc.doc_id).unwrap().sections[0].content = "New body".into();
+        assert!(!knowledge_embeddings_complete(&index, &store));
     }
 }


### PR DESCRIPTION
## Phase 1: Markdown knowledge indexing + `search_knowledge` MCP tool

Delivers the first stage of the knowledge-base capability in #118: a generic
knowledge/content-source abstraction with a filesystem Markdown provider, plus
an MCP search tool over the indexed docs.

## What's included

**Generic knowledge layer** (`src/knowledge/`)
- `ContentSource` trait + `MarkdownSource` (`.md` / `.markdown`), with the
  same exclusion policy as the code index (defaults + `.gitignore` + saved
  project excludes; symlinks and >1 MiB files skipped).
- `KnowledgeDocument` / `KnowledgeSection` model: heading-aware sectioning
  via `pulldown_cmark` (leaf chunking — each section runs to the next heading
  at any level), minimal YAML front-matter subset (tags/categories/title,
  unknown keys preserved in a JSON bag for Phase 2/OKF), stable slug-based
  section IDs, and an embedding-text helper.
- `KnowledgeIndex`: incremental re-indexing persisted under
  `~/.pitlane/indexes/<hash>/knowledge/` (`documents.bin` + `meta.json`)
  with an mtime+size fast path and blake3 content-hash fallback.
- `generate_knowledge_embeddings`: section embeddings into a separate
  `knowledge/embeddings.bin` store, reusing the shared embed client/batching
  infrastructure (hash-based skip: only new/changed sections are re-embedded).

**BM25** (`src/index/knowledge_bm25.rs`)
- Separate tantivy index over sections (name/hierarchy/content/tags/file_path/
  doc_title), OR query semantics for natural-language queries, field boosts,
  shared `"code"` tokenizer, ready-sentinel for cheap staleness checks.

**New public-tier MCP tool** (`search_knowledge`)
- Hybrid ranking: BM25 + semantic cosine similarity when embeddings exist
  (weights via `PITLANE_KNOWLEDGE_SEMANTIC_WEIGHT`, default 0.7/0.3).
- Pure-semantic fallback scan when the query has no lexical matches.
- Optional `tag` (front-matter tag) and `path_filter` (path substring) filters.
- Lazy, incremental indexing on first use — no dependency on the code index,
  docs-only repos work; embeddings are generated in the background after
  changes (deduped per project).

## Verification
- 720/720 lib tests pass; `cargo clippy -D warnings` and `cargo fmt --check`
  clean. New coverage: document model (11), BM25 (3), knowledge index/source
  (14), embedding pipeline (2), search tool (4).
- Unit work separated into atomic commits for easy review.

## Out of scope (later phases)
- OKF-specific metadata/relationships (Phase 2 — the front-matter JSON bag
  is the extension point).
- Confluence/sync tooling, editing/publishing, unified hybrid retrieval
  across code + docs (Phase 3).

This PR is a first installment towards #118 — follow-up PRs will build
Phase 2 and Phase 3 on top.
