### PR TITLE
feat: OKF-aware knowledge indexing (issue #118, Phase 2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Advanced primitive tools are hidden from `tools/list` unless the server is start
 4. Use `trace_path` for behavior, source-to-sink, config-to-effect, shortest-path, and other execution-path questions.
 5. Use `analyze_impact` for blast-radius questions before edits or refactors. Use `analyze_changes` to map a Git diff to revision-qualified symbols, impact evidence, and test candidates.
 6. Use `search_content` when you know a text snippet, log string, import path, macro name, or regex fragment but do not know the symbol boundary yet.
-7. Use `search_knowledge` for documentation questions — it searches indexed Markdown (docs, READMEs, runbooks) by heading and content, with hybrid lexical/semantic ranking when embeddings exist.
+7. Use `search_knowledge` for documentation questions — it searches indexed Markdown (docs, READMEs, runbooks) by heading and content, with hybrid lexical/semantic ranking when embeddings exist. It understands OKF v0.2 documents natively: filter by concept `type`/`status`/trust tier via `okf_type`/`status`/`min_trust`, and results carry trust, staleness, and cross-document `related_docs` relationships.
 7. Use `get_index_stats` to orient yourself in unfamiliar repos before broader exploration.
 8. Fall back to direct file reads only when editing or when full-file context is genuinely required.
 9. Treat `read_code_unit` as the preferred diff-aware read surface. Use its `read_state.status` field to decide whether to reuse the payload, expand, or reread:

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -1,88 +1,64 @@
-# AGENT HANDOFF — Knowledge-Base Indexing (issue #118), Phase 1
+# AGENT HANDOFF — Knowledge-Base Indexing (issue #118), Phase 2
 
 Branch: `feat/knowledge-indexing-phase1`
 
 ## Objective
-Phase 1 of issue #118: generic knowledge-source abstraction + filesystem Markdown
-source, heading-aware section chunking with hierarchy metadata, reuse of existing
-BM25/embedding infrastructure, incremental re-indexing, and an MCP search tool.
-OKF-specific logic stays out of core; front matter is parsed into a generic
-metadata bag now so Phase 2 (OKF fields/relationships) can build on it.
+Phase 2 of issue #118: OKF-aware indexing. OKF = Open Knowledge Format v0.2
+(spec: <https://github.com/GoogleCloudPlatform/open-knowledge-format> — note the
+spec moved out of GoogleCloudPlatform/knowledge-catalog; the `okf/` dir there is
+a frozen snapshot). Full YAML front matter parsing, typed OKF metadata
+(provenance/trust/lifecycle), metadata-aware filtering/ranking, cross-document
+link preservation, and a representative OKF bundle integration test.
 
 ## Completed work
-- [x] Unit 1: `src/knowledge/document.rs` — `KnowledgeDocument`, `KnowledgeSection`,
-      heading-aware Markdown sectioning (pulldown_cmark), minimal YAML front-matter
-      subset parser, slug-based stable section IDs, embedding-text helper. Unit tests.
-- [x] Unit 2: `src/index/knowledge_bm25.rs` — tantivy schema/build/ensure/search over
-      sections (OR semantics, field boosts, shared "code" tokenizer + escape_query).
-- [x] Unit 3: `src/knowledge/mod.rs` — `ContentSource` trait + `MarkdownSource`,
-      `KnowledgeIndex` with incremental indexing (mtime+size fast path, blake3 hash
-      fallback), documents.bin/meta.json persistence under <index_dir>/knowledge/,
-      code-index exclusion policy (defaults + .gitignore + saved excludes).
-- [x] Unit 4: `generate_knowledge_embeddings` in `src/knowledge/mod.rs` — section
-      embeddings via shared EmbedClient/EmbedStore infra into
-      `<index_dir>/knowledge/embeddings.bin`; hash-based skip; separate store file.
-- [x] Unit 5: `ensure_knowledge_index` orchestrator (incremental index → BM25
-      rebuild → persist; returns `(changed, KnowledgeIndex)`), `is_ready()` helper
-      in knowledge_bm25, and `src/tools/search_knowledge.rs` MCP tool with hybrid
-      lexical (BM25)/semantic (cosine) ranking, tag + path filters, pure-semantic
-      fallback scan, and lazy background embedding generation (deduped per
-      project). Registered in main.rs (project_field! + #[tool]) + docs.
+- [x] `src/knowledge/okf.rs` (new) — `OkfMeta`, `TrustTier`, `OkfSource`,
+      `VerifiedEvent`; `extract_okf` over full YAML front matter; `is_stale`
+      (absolute `stale_after` comparison) via `chrono` (RFC 3339).
+- [x] `src/knowledge/document.rs` — front matter now parsed with `serde_yaml`
+      (Phase 1 used a minimal YAML subset). Unknown keys still preserved in the
+      `front_matter` JSON bag (converted YAML→JSON). `KnowledgeDocument` gained
+      `okf: Option<OkfMeta>` and `links: Vec<KnowledgeLink>`.
+- [x] `src/knowledge/links.rs` (new) — pulldown_cmark link extraction,
+      bundle-relative (`/x.md`) and relative (`./x.md`) resolution to
+      project-relative normalized `.md` targets; external/anchor/code targets
+      ignored; duplicates collapse by target (first text wins).
+- [x] `src/tools/search_knowledge.rs` + `src/main.rs` — new filters
+      `okf_type`, `status`, `min_trust` (OKF filters never match plain
+      Markdown documents; invalid `min_trust` fails fast). Results expose
+      `okf_type`, `description`, `resource`, `status`, `trust_tier`, `stale`,
+      `metadata_adjustment`, `related_docs`. Ranking adjustment: +0.05
+      human-reviewed, +0.02 machine-confirmed, −0.10 stale, −0.10 deprecated,
+      −0.02 draft (clamped ±0.25), applied to the blended/lexical score in
+      BOTH paths — the lexical-only path re-sorts after adjustment.
+- [x] `tests/knowledge_okf.rs` (new) — representative OKF v0.2 bundle modeled
+      on spec Appendix A: metrics, attested computations in different
+      trust/staleness states, cross-links, `index.md`/`log.md` reserved files,
+      a plain-Markdown doc. 8 end-to-end tests.
+- [x] Docs: `docs/tools.md`, `README.md`, `AGENTS.md`.
 
 ## Important decisions
-- Separate storage under existing per-project index dir:
-  `~/.pitlane/indexes/<hash>/knowledge/` → `documents.bin`, `meta.json`,
-  `tantivy/` (sentinel `.ready.v1`), `embeddings.bin` (+`.meta.json`).
-  Code and knowledge indexes evolve independently; embedding *client/batch* infra
-  is reused but the store file is separate (different document profile).
-- IDs: doc_id = `knowledge:<relative/path.md>`; section key = `<doc_id>#<slug>`,
-  slug = slugified heading hierarchy, collision-suffixed (`-2`). Preamble sections
-  (text before first H1) use slug `preamble`. SymbolId is already a String alias,
-  so string IDs work with the existing EmbedStore type.
-- Section content = markdown from after its heading to the NEXT heading at ANY level
-  (leaf chunking, standard RAG style). Empty-content sections are kept for
-  navigation/line ranges but skipped for embeddings; BM25 indexes their name only.
-- Front matter: minimal YAML subset (top-level `key: value`, inline `[a, b]` lists,
-  block `- item` lists). Full YAML is a Phase 2 upgrade. Unknown keys preserved in
-  `front_matter` JSON bag for OKF extensibility.
-- Title resolution: front matter `title` > first H1 > file stem.
-- Tags from front matter `tags` and/or `categories`.
-- `search_knowledge` builds the knowledge index lazily + incrementally on first use
-  (no code-index dependency). When `PITLANE_EMBED_*` are set, section embedding
-  generation is triggered from a background task after doc changes or when the
-  store/embed model is stale; a per-project `EMBED_INFLIGHT` set (RwLock) dedupes
-  concurrent spawns.
-
-## Files changed
-- `src/knowledge/mod.rs` (new)
-- `src/knowledge/document.rs` (new)
-- `src/index/knowledge_bm25.rs` (new)
-- `src/index/mod.rs` (declare module)
-- `src/index/format.rs` (add `knowledge_dir()`)
-- `src/index/bm25.rs` (pub(crate): register_tokenizer, TOKENIZER_NAME, escape_query)
-- `src/lib.rs` (add `pub mod knowledge;`)
-- `src/tools/search_knowledge.rs` (new MCP tool)
-- `src/tools/mod.rs` (declare module)
-- `src/main.rs` (SearchKnowledgeRequest + project_field! registration + #[tool] handler)
-- `AGENTS.md`, `README.md`, `docs/tools.md` (tool documentation)
+- Full YAML via `serde_yaml 0.9` (deprecated upstream but stable/fine); the
+  Phase 1 minimal parser is deleted. Malformed or unterminated front matter is
+  treated as plain Markdown body (spec-strict bundles would fail, we stay
+  lenient per §11).
+- `KNOWLEDGE_META_VERSION` bumped 1 → 2 (persisted layout gained `okf`/`links`
+  fields; bincode cannot decode old payloads anyway).
+- Trust tier derivation follows spec §5.3 (bare `verified` mapping = one-event
+  list); `verified_at` = max of event timestamps. Staleness compares now >=
+  `stale_after` in Unix seconds; malformed timestamps are never stale.
+- Metadata adjustments are advisory nudges in blended-score units, not hard
+  filters; env-tunable knobs intentionally deferred (Phase 3 can revisit).
+- Computation-family fields (`runtime`, `executor`, `attester`, `parameters`)
+  are NOT modeled — they stay in the generic front-matter bag. Add typed
+  support only when a tool actually needs them.
 
 ## Tests / results
-- `cargo test --lib` → 720 passed, 0 failed. Clippy clean, fmt clean.
-- Commits: 4ea9d62 (unit 1), bfccd44 (unit 2), a5b82bf (unit 3),
-  3f2c68f (unit 4), TBD (unit 5).
+- `cargo test --lib` → 740 passed. `cargo test --test knowledge_okf` → 8 passed.
+- Clippy `-D warnings` clean, fmt clean.
+- Commits: b5874c3 (units 1+2), 7ed455f (unit 3), 2f8540a (unit 4 tests/docs),
+  7b737b0 (lexical re-sort fix).
 
-## Unresolved issues
-- None blocking. Notes: bincode cannot deserialize serde_json::Value → front matter
-  persisted as JSON string (accessor `front_matter_value()`). Setext headings fold
-  the whole preceding paragraph into the heading (CommonMark) — parser handles it.
-- Embedding dimension mismatch between a stale store and a freshly embedded section
-  is handled by skipping at save time (warn log) — a `force`/rebuild knob for the
-  knowledge store is not exposed yet (Phase 2 could add one via doctor/ensure).
-
-## Next actions
-1. (PR 1) Commit unit 5 as `closes #118`-style knowledge search feature branch work:
-   verify full suite after final fmt, commit with a message describing
-   `search_knowledge` tool, push branch, open PR (towards #118).
-2. Phase 2 (separate PR(s)): OKF metadata fields/relationships on the generic
-   front-matter bag; possibly a `force` embed rebuild knob and richer hybrid
-   weights documented.
+## Phase 3 outlook (from the issue)
+- Hybrid/unified retrieval across code + knowledge; full-document retrieval
+  after search; unified MCP search experience. The per-result `related_docs`
+  and OKF metadata in place make a graph-viewer or follow-links tool easy.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,6 +1779,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "blake3",
+ "chrono",
  "clap",
  "criterion",
  "futures",
@@ -1794,6 +1795,7 @@ dependencies = [
  "rmcp",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tantivy",
  "tempfile",
  "tokio",
@@ -2472,6 +2474,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -3352,6 +3367,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,8 @@ futures = "0.3"
 tree-sitter-solidity = "1.2"
 regex = "1"
 tempfile = "3"
+serde_yaml = "0.9"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Most users should stay on the default tool tier:
 5. Use `trace_path` for explicit source-to-sink or config-to-effect questions.
 6. Use `analyze_impact` before edits or refactors, and `analyze_changes` to review a Git diff.
 7. Use `search_content` only when you know a text fragment but not the owning symbol.
-8. Use `search_knowledge` for documentation questions — it searches indexed Markdown (docs, READMEs, runbooks) by heading and content.
+8. Use `search_knowledge` for documentation questions — it searches indexed Markdown (docs, READMEs, runbooks) by heading and content. It understands OKF v0.2 documents natively (`okf_type`/`status`/`min_trust` filters; results carry trust tier, staleness, and related-document links).
 
 Default public tier:
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -214,8 +214,11 @@ Notes:
 
 - The index is built lazily on first use. Each search hashes eligible Markdown files to catch edits even when timestamps and sizes are preserved; only changed documents are reparsed.
 - Ranking blends BM25 over section text/headings with semantic cosine similarity when `PITLANE_EMBED_URL`/`PITLANE_EMBED_MODEL` are set. Section embeddings generate in the background after changes; lexical results are always available without them.
-- Optional filters: `tag` (document front-matter tag, case-insensitive) and `path_filter` (substring of the relative file path).
+- Optional filters: `tag` (document front-matter tag, case-insensitive), `path_filter` (substring of the relative file path), and OKF metadata filters: `okf_type` (front-matter `type`, case-insensitive), `status` (`draft`/`stable`/`deprecated`), and `min_trust` (`unverified` < `machine-confirmed` < `human-reviewed`). OKF filters only match documents that carry OKF metadata.
 - Results include `file_path`, heading hierarchy, line range, a snippet, and score breakdown — open full sections with `read_code_unit` using those coordinates.
+- [Open Knowledge Format](https://github.com/GoogleCloudPlatform/open-knowledge-format) (OKF) v0.2 documents are understood natively: front matter is parsed as full YAML, and `type`/`description`/`resource`/`status`/`generated`/`verified`/`stale_after`/`sources` metadata is extracted, filtered on, and returned with each result. The derived trust tier (`verified` by `human:` actors ⇒ human-reviewed) and staleness (`stale_after` passed) are advisory ranking signals: verified concepts rank slightly higher, stale/deprecated/draft concepts slightly lower. Plain-Markdown documents remain fully usable without OKF metadata.
+- Markdown links to other knowledge documents (bundle-relative `/x.md` or relative `./x.md`) are preserved as `related_docs` in results, exposing the bundle's relationship graph.
+- Unknown front-matter keys (including OKF extension and computation fields such as `runtime`) are preserved in the index and available for future use; malformed front matter is treated as plain Markdown.
 
 ### `search_content`
 

--- a/src/knowledge/document.rs
+++ b/src/knowledge/document.rs
@@ -3,15 +3,18 @@
 //! A knowledge document is one source file (e.g. a Markdown page) parsed into
 //! heading-aware sections. Each section keeps its heading hierarchy and line
 //! range so retrieval results can be read back with exact coordinates, and the
-//! front matter is preserved as a generic metadata bag so OKF-specific fields
-//! (relationships, provenance, ...) can be modeled in later phases without
-//! changing the core structures.
+//! front matter is parsed as full YAML and preserved as a generic metadata
+//! bag so OKF-specific fields (relationships, provenance, ...) can be modeled
+//! in later phases without changing the core structures.
 
 use std::collections::HashMap;
 
 use pulldown_cmark::{Event, Parser as MarkdownParser, Tag, TagEnd};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+
+use super::links::{extract_links, KnowledgeLink};
+use super::okf::{extract_okf, OkfMeta};
 
 /// A knowledge document — one source file parsed into heading-aware sections.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -26,10 +29,19 @@ pub struct KnowledgeDocument {
     #[serde(default)]
     pub tags: Vec<String>,
     /// Raw front matter as compact JSON (empty string when absent) for fields
-    /// not yet modeled explicitly. Stored as a string because bincode cannot
-    /// deserialize `serde_json::Value` (it deserializes via `deserialize_any`).
+    /// not modeled explicitly (including OKF extension keys). Stored as a
+    /// string because bincode cannot deserialize `serde_json::Value` (it
+    /// deserializes via `deserialize_any`).
     #[serde(default)]
     pub front_matter: String,
+    /// Extracted OKF metadata, when the front matter carries a non-empty
+    /// `type` key (Open Knowledge Format v0.2).
+    #[serde(default)]
+    pub okf: Option<OkfMeta>,
+    /// Markdown links to other knowledge documents, normalized to
+    /// bundle-relative paths (spec §6). Deduplicated by target, document order.
+    #[serde(default)]
+    pub links: Vec<KnowledgeLink>,
     /// Heading-aware sections in document order.
     pub sections: Vec<KnowledgeSection>,
 }
@@ -100,6 +112,7 @@ impl KnowledgeSection {
 pub fn parse_markdown(relative_path: &str, source: &str) -> KnowledgeDocument {
     let (front_matter, body_start) = split_front_matter(source);
     let body = &source[body_start..];
+    let okf = extract_okf(&front_matter);
 
     let line_starts = line_starts(source);
     let total_lines = source.lines().count().max(1);
@@ -201,7 +214,8 @@ pub fn parse_markdown(relative_path: &str, source: &str) -> KnowledgeDocument {
         });
     }
 
-    let title = extract_title(&front_matter)
+    let fm_json = front_matter_value(&front_matter);
+    let title = extract_title(&fm_json)
         .or_else(|| {
             headings
                 .iter()
@@ -215,11 +229,13 @@ pub fn parse_markdown(relative_path: &str, source: &str) -> KnowledgeDocument {
         doc_id: KnowledgeDocument::doc_id_for(relative_path),
         file_path: relative_path.to_string(),
         title,
-        tags: extract_tags(&front_matter),
+        tags: extract_tags(&fm_json),
+        okf,
+        links: extract_links(body, relative_path),
         front_matter: if front_matter.is_null() {
             String::new()
         } else {
-            front_matter.to_string()
+            serde_json::to_string(&fm_json).unwrap_or_default()
         },
         sections,
     }
@@ -239,95 +255,74 @@ fn line_of(starts: &[usize], offset: usize) -> usize {
 
 /// Split leading YAML front matter from `source`.
 ///
-/// Returns the parsed front matter (or `Value::Null`) and the byte offset where
-/// the document body begins. Only a minimal YAML subset is supported (top-level
-/// `key: value` pairs, inline `[a, b]` lists, block `- item` lists); full YAML
-/// parsing is a later-phase upgrade. Unknown keys are preserved verbatim.
-fn split_front_matter(source: &str) -> (Value, usize) {
+/// Returns the parsed front matter (or `serde_yaml::Value::Null`) and the byte
+/// offset where the document body begins. Full YAML is supported (nested
+/// mappings, block/inline lists, flow `{a: b}` pairs) so OKF fields like
+/// `generated: { by, at }` and `sources:` entries parse correctly. YAML that
+/// fails to parse, or a block without a closing delimiter, is treated as plain
+/// Markdown. Unknown keys are preserved verbatim.
+fn split_front_matter(source: &str) -> (serde_yaml::Value, usize) {
     let mut lines = source.split_inclusive('\n');
     let Some(first) = lines.next() else {
-        return (Value::Null, 0);
+        return (serde_yaml::Value::Null, 0);
     };
     if first.trim_end() != "---" {
-        return (Value::Null, 0);
+        return (serde_yaml::Value::Null, 0);
     }
     let mut offset = first.len();
-    let mut block: Vec<&str> = Vec::new();
+    let mut block = String::new();
     for line in lines {
         if line.trim_end() == "---" || line.trim_end() == "..." {
-            return (parse_front_matter_block(&block), offset + line.len());
+            match serde_yaml::from_str(&block) {
+                Ok(value) => return (value, offset + line.len()),
+                Err(_) => return (serde_yaml::Value::Null, 0),
+            }
         }
-        block.push(line);
+        block.push_str(line);
         offset += line.len();
     }
     // No closing delimiter — treat the file as plain Markdown.
-    (Value::Null, 0)
+    (serde_yaml::Value::Null, 0)
 }
 
-fn parse_front_matter_block(block: &[&str]) -> Value {
-    let mut obj = Map::new();
-    let mut list_key: Option<String> = None;
-    for raw in block {
-        let line = raw.trim_end();
-        let trimmed = line.trim_start();
-        if trimmed.is_empty() || trimmed.starts_with('#') {
-            continue;
-        }
-        let indented = line.starts_with(' ') || line.starts_with('\t');
-        if indented && trimmed.starts_with("- ") {
-            // Block list item under the most recent empty-valued key.
-            if let Some(key) = &list_key {
-                if let Some(Value::Array(items)) = obj.get_mut(key) {
-                    items.push(Value::String(parse_scalar(&trimmed[2..])));
-                }
+/// Convert a `serde_yaml::Value` into a `serde_json::Value` for the generic
+/// front-matter bag.
+fn front_matter_value(value: &serde_yaml::Value) -> Value {
+    match value {
+        serde_yaml::Value::Null => Value::Null,
+        serde_yaml::Value::Bool(b) => Value::Bool(*b),
+        serde_yaml::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Value::Number(serde_json::Number::from(i))
+            } else if let Some(u) = n.as_u64() {
+                Value::Number(serde_json::Number::from(u))
+            } else {
+                n.as_f64()
+                    .and_then(serde_json::Number::from_f64)
+                    .map_or(Value::String(n.to_string()), Value::Number)
             }
-            continue;
         }
-        if indented {
-            // Nested mappings are not modeled in Phase 1: drop the empty list
-            // placeholder that preceded them.
-            if let Some(key) = list_key.take() {
-                if matches!(obj.get(&key), Some(Value::Array(items)) if items.is_empty()) {
-                    obj.remove(&key);
-                }
+        serde_yaml::Value::String(s) => Value::String(s.clone()),
+        serde_yaml::Value::Sequence(items) => {
+            Value::Array(items.iter().map(front_matter_value).collect())
+        }
+        serde_yaml::Value::Mapping(map) => {
+            let mut obj = Map::new();
+            for (k, v) in map {
+                let key = match k {
+                    serde_yaml::Value::String(s) => s.clone(),
+                    // Non-string mapping keys are stringified through JSON.
+                    other => front_matter_value(other)
+                        .to_string()
+                        .trim_matches('"')
+                        .to_string(),
+                };
+                obj.insert(key, front_matter_value(v));
             }
-            continue;
+            Value::Object(obj)
         }
-        list_key = None;
-        let Some(colon) = line.find(':') else {
-            continue;
-        };
-        let key = line[..colon].trim().to_string();
-        let value = line[colon + 1..].trim();
-        if key.is_empty() {
-            continue;
-        }
-        if value.is_empty() {
-            list_key = Some(key.clone());
-            obj.insert(key, Value::Array(Vec::new()));
-        } else if value.starts_with('[') && value.ends_with(']') {
-            let inner = &value[1..value.len() - 1];
-            let items: Vec<Value> = inner
-                .split(',')
-                .map(|s| Value::String(parse_scalar(s)))
-                .filter(|v| v.as_str().is_none_or(|s| !s.is_empty()))
-                .collect();
-            obj.insert(key, Value::Array(items));
-        } else {
-            obj.insert(key, Value::String(parse_scalar(value)));
-        }
-    }
-    Value::Object(obj)
-}
-
-fn parse_scalar(s: &str) -> String {
-    let s = s.trim();
-    if s.len() >= 2
-        && ((s.starts_with('"') && s.ends_with('"')) || (s.starts_with('\'') && s.ends_with('\'')))
-    {
-        s[1..s.len() - 1].to_string()
-    } else {
-        s.to_string()
+        // Unknown tags are flattened to their inner scalar.
+        serde_yaml::Value::Tagged(tag) => front_matter_value(&tag.value),
     }
 }
 
@@ -529,9 +524,34 @@ mod tests {
         assert_eq!(doc.tags, Vec::<String>::new());
         let fm = doc.front_matter_value();
         assert_eq!(fm["empty"], Value::Array(vec![Value::String("a".into())]));
-        // Nested mappings are skipped in Phase 1.
-        assert!(fm.get("nested").is_none());
+        // Full YAML parses nested mappings.
+        assert_eq!(fm["nested"]["deep"], Value::String("value".into()));
         assert_eq!(fm["ok"], Value::String("yes".into()));
+    }
+
+    #[test]
+    fn okf_front_matter_is_extracted_and_bag_preserved() {
+        let source = "---\ntype: Metric\ntitle: Revenue\nstatus: stable\ngenerated: { by: agent/gemini, at: 2026-06-20T22:53:05Z }\nverified: { by: human:ana, at: 2026-06-25T09:00:00Z }\nruntime: bigquery\n---\n# Definition\nBody.\n";
+        let doc = parse_markdown("finance/revenue.md", source);
+        let okf = doc.okf.as_ref().unwrap();
+        assert_eq!(okf.doc_type, "Metric");
+        assert_eq!(okf.trust_tier, super::super::okf::TrustTier::HumanReviewed);
+        assert_eq!(okf.generated_by.as_deref(), Some("agent/gemini"));
+        // Unmodeled OKF keys stay in the generic bag.
+        assert_eq!(doc.front_matter_value()["runtime"], "bigquery");
+
+        // Plain Markdown (no `type`) gets no OKF metadata.
+        let doc = parse_markdown("a.md", "---\ntitle: Plain\n---\nBody.\n");
+        assert!(doc.okf.is_none());
+    }
+
+    #[test]
+    fn malformed_yaml_front_matter_is_treated_as_body() {
+        let source = "---\ntitle: [unclosed\nmore: {broken\n---\nBody.\n";
+        let doc = parse_markdown("a.md", source);
+        assert_eq!(doc.front_matter, String::new());
+        assert!(doc.okf.is_none());
+        assert!(doc.sections.iter().any(|s| s.section_id == "preamble"));
     }
 
     #[test]

--- a/src/knowledge/links.rs
+++ b/src/knowledge/links.rs
@@ -1,0 +1,180 @@
+//! Markdown link extraction between knowledge documents (OKF spec §6).
+//!
+//! Concepts relate to each other via standard markdown links. Links whose
+//! target is another document (`.md`) are resolved to bundle-relative paths
+//! and stored on the [`KnowledgeDocument`](crate::knowledge::document)
+//! so search results can expose relationships without re-parsing bodies.
+//! Absolute (`/tables/orders.md`) and relative (`./other.md`,
+//! `../computations/revenue.md`) forms are supported; external URLs,
+//! anchors-only links, and non-document targets are ignored. Per spec §6.1,
+//! broken links are tolerated — targets are not validated here.
+
+use serde::{Deserialize, Serialize};
+
+/// A link from one knowledge document to another.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct KnowledgeLink {
+    /// Normalized target path relative to the project root, forward slashes
+    /// (e.g. `computations/revenue.md`).
+    pub target: String,
+    /// Link text as written in the body.
+    pub text: String,
+}
+
+/// Extract document-to-document links from `body`. `relative_path` (project-
+/// relative, forward slashes) is the containing document; relative targets are
+/// resolved against its parent directory. Duplicates collapse on target
+/// (first link text wins).
+pub fn extract_links(body: &str, relative_path: &str) -> Vec<KnowledgeLink> {
+    let base_dir = match relative_path.rfind('/') {
+        Some(i) => &relative_path[..i],
+        None => "",
+    };
+
+    let mut links: Vec<KnowledgeLink> = Vec::new();
+    let mut current: Option<KnowledgeLink> = None;
+    for (event, _) in pulldown_cmark::Parser::new(body).into_offset_iter() {
+        match event {
+            pulldown_cmark::Event::Start(pulldown_cmark::Tag::Link { dest_url, .. }) => {
+                current = normalize_target(&dest_url, base_dir).map(|link| KnowledgeLink {
+                    target: link.target,
+                    text: String::new(),
+                });
+            }
+            pulldown_cmark::Event::Text(text) | pulldown_cmark::Event::Code(text)
+                if current.is_some() =>
+            {
+                if let Some(link) = current.as_mut() {
+                    if !link.text.is_empty() {
+                        link.text.push(' ');
+                    }
+                    link.text.push_str(&text);
+                }
+            }
+            pulldown_cmark::Event::End(pulldown_cmark::TagEnd::Link) => {
+                if let Some(link) = current.take() {
+                    // Deduplicate by target: the first link text wins.
+                    if links.iter().any(|l| l.target == link.target) {
+                        continue;
+                    }
+                    links.push(link);
+                }
+            }
+            _ => {}
+        }
+    }
+    links
+}
+
+/// Normalize a link destination to a project-relative `.md` path, or `None`
+/// when the target is not a document link.
+fn normalize_target(dest: &str, base_dir: &str) -> Option<KnowledgeLink> {
+    let dest = dest.trim();
+    if dest.is_empty() || dest.starts_with("mailto:") {
+        return None;
+    }
+    if dest.contains("://") || dest.starts_with('#') {
+        return None;
+    }
+    // Strip a fragment/anchor: `other.md#section` still targets `other.md`.
+    let (path, _anchor) = dest.split_once('#').unwrap_or((dest, ""));
+    if !path.to_ascii_lowercase().ends_with(".md") {
+        return None;
+    }
+
+    let target = if let Some(stripped) = path.strip_prefix('/') {
+        // Bundle-relative: interpreted against the project root.
+        normalize_segments(stripped)?
+    } else {
+        let joined = if base_dir.is_empty() {
+            path.to_string()
+        } else {
+            format!("{base_dir}/{path}")
+        };
+        normalize_segments(&joined)?
+    };
+    if target.is_empty() {
+        return None;
+    }
+    Some(KnowledgeLink {
+        target,
+        text: String::new(),
+    })
+}
+
+/// Collapse `.` / `..` segments in a `/`-separated path. Returns `None` when
+/// the path escapes above the root.
+fn normalize_segments(path: &str) -> Option<String> {
+    let mut segments: Vec<&str> = Vec::new();
+    for segment in path.split('/') {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                segments.pop()?;
+            }
+            other => segments.push(other),
+        }
+    }
+    Some(segments.join("/"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bundle_relative_and_relative_links_are_normalized() {
+        let body = "Join key: [customers](/tables/customers.md) and [revenue](../computations/revenue.md) plus [neighbour](./other.md#section).";
+        let links = extract_links(body, "metrics/income.md");
+        assert_eq!(
+            links,
+            vec![
+                KnowledgeLink {
+                    target: "tables/customers.md".into(),
+                    text: "customers".into()
+                },
+                KnowledgeLink {
+                    target: "computations/revenue.md".into(),
+                    text: "revenue".into()
+                },
+                KnowledgeLink {
+                    target: "metrics/other.md".into(),
+                    text: "neighbour".into()
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn root_level_relative_links_resolve_against_the_root() {
+        let links = extract_links("[other](other.md) [up](../outside.md)", "readme.md");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target, "other.md");
+    }
+
+    #[test]
+    fn external_and_non_document_targets_are_ignored() {
+        let body = "[web](https://example.com/doc.md) [anchor](#section) [png](img.png) [mail](mailto:a@b.c) [empty]( )";
+        assert!(extract_links(body, "a.md").is_empty());
+    }
+
+    #[test]
+    fn escaping_paths_are_rejected() {
+        assert!(extract_links("[x](../../outside.md)", "a.md").is_empty());
+    }
+
+    #[test]
+    fn duplicates_collapse_by_target_and_broken_links_are_kept() {
+        let body = "[a](/tables/orders.md) [b](/tables/orders.md) [missing](/nope/ghost.md)";
+        let links = extract_links(body, "m.md");
+        assert_eq!(links.len(), 2);
+        assert_eq!(links[0].text, "a");
+        assert_eq!(links[1].target, "nope/ghost.md");
+    }
+
+    #[test]
+    fn links_in_code_and_autolinks_are_not_extracted() {
+        let body = "```\n[x](/tables/orders.md)\n```\nInline `<https://example.com>` and plain /tables/orders.md text.";
+        assert!(extract_links(body, "a.md").is_empty());
+    }
+}

--- a/src/knowledge/mod.rs
+++ b/src/knowledge/mod.rs
@@ -7,6 +7,8 @@
 //! its own walk, persistence format, and BM25 schema.
 
 pub mod document;
+pub mod links;
+pub mod okf;
 
 use std::collections::{HashMap, HashSet};
 use std::io::Write as _;
@@ -31,8 +33,9 @@ use crate::path_policy::{read_regular_file, regular_file_metadata};
 /// Files larger than this are skipped (same limit as code indexing).
 const MAX_KNOWLEDGE_FILE_BYTES: u64 = 1024 * 1024; // 1 MiB
 
-/// Bump when the persisted knowledge layout changes incompatibly.
-pub const KNOWLEDGE_META_VERSION: u32 = 1;
+/// Bump when the persisted knowledge layout changes incompatibly. v2 added
+/// typed OKF metadata and links to `KnowledgeDocument` (Phase 2, issue #118).
+pub const KNOWLEDGE_META_VERSION: u32 = 2;
 
 // ---------------------------------------------------------------------------
 // Content sources

--- a/src/knowledge/okf.rs
+++ b/src/knowledge/okf.rs
@@ -1,0 +1,364 @@
+//! OKF (Open Knowledge Format) v0.2 metadata extraction.
+//!
+//! Extracts the front-matter families defined by the OKF spec (provenance,
+//! trust, lifecycle) into a typed [`OkfMeta`] attached to a
+//! [`KnowledgeDocument`]. Following the spec's conformance rules, consumers
+//! here are deliberately lenient: missing optional fields, unknown `type`
+//! values, and unrecognized extra keys never reject a document — unknown keys
+//! stay in the document's generic front-matter bag.
+//!
+//! Spec: <https://github.com/GoogleCloudPlatform/open-knowledge-format> (v0.2).
+
+use serde::{Deserialize, Serialize};
+
+/// Trust tier derived from `verified` (spec §5.3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default)]
+pub enum TrustTier {
+    /// No `verified` key.
+    #[default]
+    Unverified,
+    /// `verified` only by non-`human:` actors.
+    MachineConfirmed,
+    /// `verified` by at least one `human:<id>` actor.
+    HumanReviewed,
+}
+
+impl TrustTier {
+    /// Lowercase name used in tool responses and filters.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TrustTier::Unverified => "unverified",
+            TrustTier::MachineConfirmed => "machine-confirmed",
+            TrustTier::HumanReviewed => "human-reviewed",
+        }
+    }
+
+    /// Parse a filter value (case-insensitive; `machine_confirmed` with an
+    /// underscore is accepted too).
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().replace('_', "-").as_str() {
+            "unverified" => Some(TrustTier::Unverified),
+            "machine-confirmed" => Some(TrustTier::MachineConfirmed),
+            "human-reviewed" => Some(TrustTier::HumanReviewed),
+            _ => None,
+        }
+    }
+
+    /// True when `verified` contains at least one `human:` actor.
+    fn from_verified(events: &[VerifiedEvent]) -> Self {
+        if events
+            .iter()
+            .any(|e| e.by.as_deref().is_some_and(|by| by.starts_with("human:")))
+        {
+            TrustTier::HumanReviewed
+        } else if events.is_empty() {
+            TrustTier::Unverified
+        } else {
+            TrustTier::MachineConfirmed
+        }
+    }
+}
+
+/// One `verified` entry: `{ by, at }`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VerifiedEvent {
+    pub by: Option<String>,
+    pub at: Option<String>,
+}
+
+/// One `sources` entry (spec §5.1).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OkfSource {
+    pub id: Option<String>,
+    pub resource: Option<String>,
+    pub title: Option<String>,
+    pub author: Option<String>,
+    pub usage_count: Option<u64>,
+    pub last_modified: Option<String>,
+}
+
+/// Extracted OKF front-matter families.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct OkfMeta {
+    /// `type` — the only spec-required key. A document with a non-empty
+    /// `type` is treated as an OKF concept.
+    pub doc_type: String,
+    pub description: Option<String>,
+    pub resource: Option<String>,
+    /// `status`: `draft` | `stable` | `deprecated`; absent ⇒ `stable`.
+    pub status: Option<String>,
+    /// `stale_after` as a raw ISO 8601 datetime string.
+    pub stale_after: Option<String>,
+    pub trust_tier: TrustTier,
+    pub generated_by: Option<String>,
+    pub generated_at: Option<String>,
+    /// Latest `verified[].at`, when present.
+    pub verified_at: Option<String>,
+    pub sources: Vec<OkfSource>,
+    pub usage_window_from: Option<String>,
+    pub usage_window_to: Option<String>,
+    /// `okf_version` from a bundle-root `index.md` (or any document).
+    pub okf_version: Option<String>,
+}
+
+impl OkfMeta {
+    /// True when this document carries the spec-required `type` key.
+    pub fn is_okf(&self) -> bool {
+        !self.doc_type.is_empty()
+    }
+}
+
+/// Extract OKF metadata from parsed front matter. Returns `Ok(None)` when the
+/// front matter has no non-empty `type` key (plain Markdown / non-OKF docs).
+///
+/// Lenient per spec §11: wrong-shaped values for individual fields are
+/// skipped, not errors.
+pub fn extract_okf(front_matter: &serde_yaml::Value) -> Option<OkfMeta> {
+    let map = front_matter.as_mapping()?;
+    let doc_type = str_field(map, "type").unwrap_or_default();
+    if doc_type.is_empty() {
+        return None;
+    }
+
+    let verified = verified_events(map);
+    let sources = sources_list(map);
+    let (usage_window_from, usage_window_to) = usage_window(map);
+
+    let verified_at = verified
+        .iter()
+        .filter_map(|e| e.at.clone())
+        .max()
+        .filter(|s| !s.is_empty());
+
+    Some(OkfMeta {
+        doc_type,
+        description: str_field(map, "description"),
+        resource: str_field(map, "resource"),
+        status: str_field(map, "status"),
+        stale_after: str_field(map, "stale_after"),
+        trust_tier: TrustTier::from_verified(&verified),
+        generated_by: map_field(map, "generated").and_then(|g| str_field(g, "by")),
+        generated_at: map_field(map, "generated").and_then(|g| str_field(g, "at")),
+        verified_at,
+        sources,
+        usage_window_from,
+        usage_window_to,
+        okf_version: str_field(map, "okf_version"),
+    })
+}
+
+/// True when the document's `stale_after` instant is at or before `now_secs`.
+/// Malformed timestamps are never stale.
+pub fn is_stale(meta: &OkfMeta, now_secs: i64) -> bool {
+    meta.stale_after
+        .as_deref()
+        .and_then(parse_iso8601_secs)
+        .is_some_and(|t| now_secs >= t)
+}
+
+/// Parse an ISO 8601 datetime with explicit offset into Unix seconds.
+pub fn parse_iso8601_secs(s: &str) -> Option<i64> {
+    chrono::DateTime::parse_from_rfc3339(s.trim())
+        .ok()
+        .map(|dt| dt.timestamp())
+}
+
+/// Current time as Unix seconds (0 on clock failure, matching FileState).
+pub fn now_secs() -> i64 {
+    chrono::Utc::now().timestamp()
+}
+
+fn as_str(value: &serde_yaml::Value) -> Option<String> {
+    match value {
+        serde_yaml::Value::String(s) => Some(s.clone()),
+        serde_yaml::Value::Number(n) => Some(n.to_string()),
+        serde_yaml::Value::Bool(b) => Some(b.to_string()),
+        _ => None,
+    }
+}
+
+fn str_field(map: &serde_yaml::Mapping, key: &str) -> Option<String> {
+    map.get(serde_yaml::Value::String(key.into()))
+        .and_then(as_str)
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn map_field<'a>(map: &'a serde_yaml::Mapping, key: &str) -> Option<&'a serde_yaml::Mapping> {
+    match map.get(serde_yaml::Value::String(key.into())) {
+        Some(serde_yaml::Value::Mapping(m)) => Some(m),
+        _ => None,
+    }
+}
+
+/// `verified`: a list of `{ by, at }` events, or a bare mapping treated as a
+/// one-element list (spec §5.2 MUST).
+fn verified_events(map: &serde_yaml::Mapping) -> Vec<VerifiedEvent> {
+    let key = serde_yaml::Value::String("verified".into());
+    let events: Vec<VerifiedEvent> = match map.get(&key) {
+        Some(serde_yaml::Value::Sequence(items)) => items
+            .iter()
+            .filter_map(|v| serde_yaml::from_value(v.clone()).ok())
+            .collect(),
+        Some(v @ serde_yaml::Value::Mapping(_)) => {
+            serde_yaml::from_value(v.clone()).ok().into_iter().collect()
+        }
+        _ => Vec::new(),
+    };
+    events
+        .into_iter()
+        .filter(|e| e.by.is_some() || e.at.is_some())
+        .collect()
+}
+
+fn sources_list(map: &serde_yaml::Mapping) -> Vec<OkfSource> {
+    let Some(serde_yaml::Value::Sequence(items)) =
+        map.get(serde_yaml::Value::String("sources".into()))
+    else {
+        return Vec::new();
+    };
+    items
+        .iter()
+        .filter_map(|v| {
+            let m = v.as_mapping()?;
+            // `resource` is required within an entry (spec §5.1).
+            str_field(m, "resource")?;
+            Some(OkfSource {
+                id: str_field(m, "id"),
+                resource: str_field(m, "resource"),
+                title: str_field(m, "title"),
+                author: str_field(m, "author"),
+                usage_count: m
+                    .get(serde_yaml::Value::String("usage_count".into()))
+                    .and_then(|v| v.as_u64()),
+                last_modified: str_field(m, "last_modified"),
+            })
+        })
+        .collect()
+}
+
+fn usage_window(map: &serde_yaml::Mapping) -> (Option<String>, Option<String>) {
+    let Some(m) = map_field(map, "usage_window") else {
+        return (None, None);
+    };
+    (str_field(m, "from"), str_field(m, "to"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn front_matter(yaml: &str) -> serde_yaml::Value {
+        serde_yaml::from_str(yaml).unwrap()
+    }
+
+    #[test]
+    fn minimal_concept_is_okf() {
+        let meta = extract_okf(&front_matter("type: Playbook\n")).unwrap();
+        assert!(meta.is_okf());
+        assert_eq!(meta.doc_type, "Playbook");
+        assert_eq!(meta.trust_tier, TrustTier::Unverified);
+        assert_eq!(meta.status, None);
+    }
+
+    #[test]
+    fn missing_or_empty_type_is_not_okf() {
+        assert!(extract_okf(&front_matter("title: Just a doc\n")).is_none());
+        assert!(extract_okf(&front_matter("type: \"\"\n")).is_none());
+        // Scalar front matter (not a mapping) is not OKF.
+        assert!(extract_okf(&front_matter("just text")).is_none());
+    }
+
+    #[test]
+    fn trust_tiers_follow_verified_actors() {
+        let unverified = extract_okf(&front_matter("type: Metric\n")).unwrap();
+        assert_eq!(unverified.trust_tier, TrustTier::Unverified);
+
+        let machine = extract_okf(&front_matter(
+            "type: Metric\nverified: { by: process:nightly, at: 2026-06-26T02:00:00Z }\n",
+        ))
+        .unwrap();
+        assert_eq!(machine.trust_tier, TrustTier::MachineConfirmed);
+        assert_eq!(machine.verified_at.as_deref(), Some("2026-06-26T02:00:00Z"));
+
+        // Bare mapping verified counts as one event; latest `at` wins.
+        let human = extract_okf(&front_matter(
+            "type: Metric\nverified:\n  - { by: human:ana, at: 2026-06-25T09:00:00Z }\n  - { by: process:nightly, at: 2026-06-26T02:00:00Z }\n",
+        ))
+        .unwrap();
+        assert_eq!(human.trust_tier, TrustTier::HumanReviewed);
+        assert_eq!(human.verified_at.as_deref(), Some("2026-06-26T02:00:00Z"));
+    }
+
+    #[test]
+    fn full_front_matter_extracts_every_family() {
+        let meta = extract_okf(&front_matter(
+            "type: Attested Computation\ntitle: Revenue\ndescription: Recognized revenue.\nresource: /tables/orders\nstatus: deprecated\nstale_after: 2026-09-23T00:00:00Z\nruntime: bigquery\ngenerated: { by: agent/gemini, at: 2026-06-20T22:53:05Z }\nverified: { by: human:ana, at: 2026-06-25T09:00:00Z }\nokf_version: \"0.2\"\nusage_window: { from: 2026-06-01T00:00:00Z, to: 2026-06-30T00:00:00Z }\nsources:\n  - id: rev-policy\n    resource: https://wiki.acme/finance/revenue\n    title: Revenue policy\n    author: team:finance\n    usage_count: 5000\n    last_modified: 2026-04-02T00:00:00Z\n  - title: no resource key — skipped\n",
+        ))
+        .unwrap();
+        assert_eq!(meta.doc_type, "Attested Computation");
+        assert_eq!(meta.description.as_deref(), Some("Recognized revenue."));
+        assert_eq!(meta.resource.as_deref(), Some("/tables/orders"));
+        assert_eq!(meta.status.as_deref(), Some("deprecated"));
+        assert_eq!(meta.stale_after.as_deref(), Some("2026-09-23T00:00:00Z"));
+        assert_eq!(meta.trust_tier, TrustTier::HumanReviewed);
+        assert_eq!(meta.generated_by.as_deref(), Some("agent/gemini"));
+        assert_eq!(meta.okf_version.as_deref(), Some("0.2"));
+        assert_eq!(meta.sources.len(), 1);
+        assert_eq!(meta.sources[0].usage_count, Some(5000));
+        assert_eq!(
+            meta.usage_window_from.as_deref(),
+            Some("2026-06-01T00:00:00Z")
+        );
+        // Spec-computation fields like `runtime` are not modeled; they stay in
+        // the generic bag at the document level.
+    }
+
+    #[test]
+    fn wrong_shaped_fields_are_skipped_not_errors() {
+        let meta = extract_okf(&front_matter(
+            "type: Metric\ndescription:\n  - not a string\nverified: nonsense\nsources: not-a-list\n",
+        ))
+        .unwrap();
+        assert_eq!(meta.doc_type, "Metric");
+        assert_eq!(meta.description, None);
+        assert_eq!(meta.trust_tier, TrustTier::Unverified);
+        assert!(meta.sources.is_empty());
+    }
+
+    #[test]
+    fn staleness_is_absolute_and_lenient() {
+        let mut meta = OkfMeta {
+            doc_type: "Metric".into(),
+            stale_after: Some("2026-09-23T00:00:00Z".into()),
+            ..Default::default()
+        };
+        assert!(is_stale(
+            &meta,
+            parse_iso8601_secs("2026-09-23T00:00:00Z").unwrap()
+        ));
+        assert!(!is_stale(
+            &meta,
+            parse_iso8601_secs("2026-09-22T23:59:59Z").unwrap()
+        ));
+
+        meta.stale_after = Some("not a timestamp".into());
+        assert!(!is_stale(&meta, i64::MAX / 2));
+
+        meta.stale_after = None;
+        assert!(!is_stale(&meta, i64::MAX / 2));
+    }
+
+    #[test]
+    fn trust_tier_parse_accepts_filter_spellings() {
+        assert_eq!(
+            TrustTier::parse("Human-Reviewed"),
+            Some(TrustTier::HumanReviewed)
+        );
+        assert_eq!(
+            TrustTier::parse("machine_confirmed"),
+            Some(TrustTier::MachineConfirmed)
+        );
+        assert_eq!(TrustTier::parse("bogus"), None);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -226,6 +226,12 @@ pub struct SearchKnowledgeRequest {
     pub tag: Option<String>,
     /// Optional substring filter on relative file paths (e.g., "docs/runbooks").
     pub path_filter: Option<String>,
+    /// Optional OKF concept-type filter (front matter `type`, e.g. "Playbook", "Metric"). Case-insensitive. Only OKF documents match.
+    pub okf_type: Option<String>,
+    /// Optional OKF lifecycle filter: "draft", "stable", or "deprecated".
+    pub status: Option<String>,
+    /// Optional minimum OKF trust tier: "unverified", "machine-confirmed", or "human-reviewed". Results must be at least this verified.
+    pub min_trust: Option<String>,
     /// Maximum number of sections to return (default 8, max 50).
     pub limit: Option<usize>,
 }
@@ -1022,7 +1028,7 @@ impl PitlaneMcp {
     }
 
     #[tool(
-        description = "Search the project's Markdown knowledge base (docs/README/runbooks) by heading and content with lexical + semantic ranking when embeddings exist. Prefer this for documentation questions; use read_code_unit on a result to open the full section.",
+        description = "Search the project's Markdown knowledge base (docs/README/runbooks) by heading and content with lexical + semantic ranking when embeddings exist; OKF metadata (type/status/trust tier) can be used for filtering. Prefer this for documentation questions; use read_code_unit on a result to open the full section.",
         meta = tool_meta("search docs documentation markdown knowledge readme runbook"),
         annotations(
             read_only_hint = true,
@@ -1040,6 +1046,9 @@ impl PitlaneMcp {
             query: req.query,
             tag: req.tag,
             path_filter: req.path_filter,
+            okf_type: req.okf_type,
+            status: req.status,
+            min_trust: req.min_trust,
             limit: req.limit,
             embed_config: self.embed_config.clone(),
         };

--- a/src/tools/search_knowledge.rs
+++ b/src/tools/search_knowledge.rs
@@ -239,15 +239,18 @@ pub async fn search_knowledge(params: SearchKnowledgeParams) -> anyhow::Result<V
         out.truncate(limit);
         out
     } else {
-        // No semantic signal: keep BM25 order (already ranked).
-        std::mem::take(&mut candidates)
+        // No semantic signal: BM25 order adjusted by metadata, then re-sorted
+        // because the adjustment can reorder near-equal lexical scores.
+        let mut out: Vec<(f64, Candidate)> = std::mem::take(&mut candidates)
             .into_iter()
-            .take(limit)
             .map(|c| {
                 let score = adjusted(&c, c.bm25_score.unwrap_or(0.0));
                 (round_frac3(f64::from(score)), c)
             })
-            .collect::<Vec<_>>()
+            .collect();
+        out.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+        out.truncate(limit);
+        out
     };
 
     // ── Response ────────────────────────────────────────────────────────────

--- a/src/tools/search_knowledge.rs
+++ b/src/tools/search_knowledge.rs
@@ -15,7 +15,8 @@ use crate::embed::store::{EmbedStore, EmbedStoreMetadata};
 use crate::embed::EmbedConfig;
 use crate::error::ToolError;
 use crate::index::format::knowledge_dir;
-use crate::knowledge::{document, generate_knowledge_embeddings, with_knowledge_index};
+use crate::knowledge::okf::{OkfMeta, TrustTier};
+use crate::knowledge::{document, generate_knowledge_embeddings, okf, with_knowledge_index};
 use crate::path_policy::resolve_project_path;
 use crate::tools::steering::{attach_steering, build_steering};
 
@@ -36,8 +37,23 @@ pub struct SearchKnowledgeParams {
     pub tag: Option<String>,
     /// Optional substring filter on the relative file path.
     pub path_filter: Option<String>,
+    /// Optional OKF concept-type filter (`type` front matter), case-insensitive.
+    pub okf_type: Option<String>,
+    /// Optional OKF lifecycle filter: `draft`, `stable`, or `deprecated`.
+    pub status: Option<String>,
+    /// Optional minimum OKF trust tier: `unverified`, `machine-confirmed`,
+    /// or `human-reviewed`.
+    pub min_trust: Option<String>,
     pub limit: Option<usize>,
     pub embed_config: Option<Arc<EmbedConfig>>,
+}
+
+/// Document-level filters resolved once per call.
+struct DocFilter<'a> {
+    tag: Option<&'a str>,
+    okf_type: Option<&'a str>,
+    status: Option<&'a str>,
+    min_trust: Option<TrustTier>,
 }
 
 /// One ranked result section with its score breakdown.
@@ -51,6 +67,14 @@ struct Candidate {
     line_end: usize,
     snippet: String,
     bm25_score: Option<f32>,
+    /// OKF metadata when the document is an OKF concept.
+    okf: Option<OkfMeta>,
+    /// Outgoing links to other knowledge documents.
+    links: Vec<crate::knowledge::links::KnowledgeLink>,
+    /// True when the document's `stale_after` instant has passed.
+    stale: bool,
+    /// Score adjustment from OKF trust/lifecycle signals.
+    metadata_adjustment: f32,
 }
 
 pub async fn search_knowledge(params: SearchKnowledgeParams) -> anyhow::Result<Value> {
@@ -63,6 +87,39 @@ pub async fn search_knowledge(params: SearchKnowledgeParams) -> anyhow::Result<V
     }
 
     let canonical = resolve_project_path(&params.project)?;
+    // Validate filter values up front so typos fail fast instead of silently
+    // returning nothing.
+    let doc_filter = DocFilter {
+        tag: params
+            .tag
+            .as_deref()
+            .map(str::trim)
+            .filter(|t| !t.is_empty()),
+        okf_type: params
+            .okf_type
+            .as_deref()
+            .map(str::trim)
+            .filter(|t| !t.is_empty()),
+        status: params
+            .status
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty()),
+        min_trust: params.min_trust.as_deref().and_then(TrustTier::parse),
+    };
+    if let Some(min_trust) = params
+        .min_trust
+        .as_deref()
+        .filter(|_| doc_filter.min_trust.is_none())
+    {
+        return Err(ToolError::InvalidArgument {
+            param: "min_trust".to_string(),
+            message: format!(
+                "invalid trust tier {min_trust:?}: use unverified, machine-confirmed, or human-reviewed"
+            ),
+        }
+        .into());
+    }
     let limit = params.limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT);
     let fetch = candidate_fetch(limit);
     // Incremental indexing may walk many files — keep it off the async runtime.
@@ -99,9 +156,8 @@ pub async fn search_knowledge(params: SearchKnowledgeParams) -> anyhow::Result<V
     // ── Lexical candidates (BM25 over sections) ────────────────────────────
     let mut candidates: Vec<Candidate> = Vec::new();
     for hit in &hits {
-        if let Some(mut cand) =
-            resolve_candidate(&index, hit.section_id.as_str(), params.tag.as_deref())
-                .filter(|c| path_matches(params.path_filter.as_deref(), &c.file_path))
+        if let Some(mut cand) = resolve_candidate(&index, hit.section_id.as_str(), &doc_filter)
+            .filter(|c| path_matches(params.path_filter.as_deref(), &c.file_path))
         {
             cand.bm25_score = Some(hit.score);
             candidates.push(cand);
@@ -143,7 +199,7 @@ pub async fn search_knowledge(params: SearchKnowledgeParams) -> anyhow::Result<V
             return Ok(empty_response(&index, &params.query));
         };
         for id in scan_store.vectors.keys() {
-            if let Some(cand) = resolve_candidate(&index, id, params.tag.as_deref())
+            if let Some(cand) = resolve_candidate(&index, id, &doc_filter)
                 .filter(|c| path_matches(params.path_filter.as_deref(), &c.file_path))
             {
                 candidates.push(cand);
@@ -152,8 +208,10 @@ pub async fn search_knowledge(params: SearchKnowledgeParams) -> anyhow::Result<V
     }
 
     let sem_weight = semantic_weight();
-    // Hybrid: weighted blend of cosine similarity and max-normalized BM25.
-    // Without a query vector we keep the lexical ranking as-is.
+    // Hybrid: weighted blend of cosine similarity and max-normalized BM25,
+    // plus an OKF trust/lifecycle adjustment. Without a query vector we keep
+    // the lexical ranking as-is (still adjusted).
+    let adjusted = |cand: &Candidate, base: f32| (base + cand.metadata_adjustment).max(0.0);
     let scored: Vec<(f64, Candidate)> = if let Some(qv) = query_vec.as_ref() {
         let max_bm25 = candidates
             .iter()
@@ -175,7 +233,7 @@ pub async fn search_knowledge(params: SearchKnowledgeParams) -> anyhow::Result<V
                 (_, Some(l)) => l,
                 (None, None) => 0.0,
             };
-            out.push((round_frac3(f64::from(score)), cand));
+            out.push((round_frac3(f64::from(adjusted(&cand, score))), cand));
         }
         out.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
         out.truncate(limit);
@@ -185,7 +243,10 @@ pub async fn search_knowledge(params: SearchKnowledgeParams) -> anyhow::Result<V
         std::mem::take(&mut candidates)
             .into_iter()
             .take(limit)
-            .map(|c| (round_frac3(f64::from(c.bm25_score.unwrap_or(0.0))), c))
+            .map(|c| {
+                let score = adjusted(&c, c.bm25_score.unwrap_or(0.0));
+                (round_frac3(f64::from(score)), c)
+            })
             .collect::<Vec<_>>()
     };
 
@@ -197,6 +258,7 @@ pub async fn search_knowledge(params: SearchKnowledgeParams) -> anyhow::Result<V
     let results: Vec<Value> = scored
         .into_iter()
         .map(|(score, c)| {
+            let okf = c.okf.as_ref();
             json!({
                 "section_id": c.full_section_id,
                 "file_path": c.file_path,
@@ -207,6 +269,21 @@ pub async fn search_knowledge(params: SearchKnowledgeParams) -> anyhow::Result<V
                 "tags": if c.tags.is_empty() { Value::Null } else { json!(c.tags) },
                 "snippet": c.snippet,
                 "score": score,
+                "okf_type": okf.and_then(|m| (!m.doc_type.is_empty()).then(|| json!(m.doc_type))),
+                "description": okf.and_then(|m| m.description.as_deref().map(|d| json!(d))),
+                "resource": okf.and_then(|m| m.resource.as_deref().map(|r| json!(r))),
+                "status": okf.and_then(|m| m.status.as_deref().map(|st| json!(st))),
+                "trust_tier": okf.map(|m| json!(m.trust_tier.as_str())),
+                "stale": c.stale,
+                "metadata_adjustment": round_frac3(f64::from(c.metadata_adjustment)),
+                "related_docs": if c.links.is_empty() {
+                    Value::Null
+                } else {
+                    json!(c.links.iter().map(|l| json!({
+                        "target": l.target,
+                        "text": l.text,
+                    })).collect::<Vec<_>>())
+                },
             })
         })
         .collect();
@@ -263,16 +340,41 @@ pub async fn search_knowledge(params: SearchKnowledgeParams) -> anyhow::Result<V
 fn resolve_candidate(
     index: &crate::knowledge::KnowledgeIndex,
     full_id: &str,
-    tag_filter: Option<&str>,
+    filter: &DocFilter<'_>,
 ) -> Option<Candidate> {
     let (doc_id, slug) = full_id.split_once('#')?;
     let doc = index.documents.get(doc_id)?;
-    if let Some(tag) = tag_filter.filter(|t| !t.trim().is_empty()) {
+    if let Some(tag) = filter.tag {
         if !matches_tag(&doc.tags, tag) {
             return None;
         }
     }
+    let okf = doc.okf.clone();
+    if let Some(meta) = &okf {
+        if let Some(okf_type) = filter.okf_type {
+            if !meta.doc_type.eq_ignore_ascii_case(okf_type) {
+                return None;
+            }
+        }
+        if let Some(status) = filter.status {
+            match meta.status.as_deref().unwrap_or("stable") {
+                s if s.eq_ignore_ascii_case(status) => {}
+                _ => return None,
+            }
+        }
+        if let Some(min_trust) = filter.min_trust {
+            if meta.trust_tier < min_trust {
+                return None;
+            }
+        }
+    } else if filter.okf_type.is_some() || filter.status.is_some() || filter.min_trust.is_some() {
+        // OKF filters never match plain-Markdown documents.
+        return None;
+    }
     let section = doc.sections.iter().find(|s| s.section_id == slug)?.clone();
+    let stale = okf
+        .as_ref()
+        .is_some_and(|m| okf::is_stale(m, okf::now_secs()));
     Some(Candidate {
         full_section_id: full_id.to_string(),
         file_path: doc.file_path.clone(),
@@ -287,7 +389,35 @@ fn resolve_candidate(
         line_end: section.line_end,
         snippet: make_snippet(&section.content),
         bm25_score: None,
+        metadata_adjustment: metadata_adjustment(okf.as_ref(), stale),
+        stale,
+        okf,
+        links: doc.links.clone(),
     })
+}
+
+/// Score adjustment from OKF trust and lifecycle signals. Advisory nudges, in
+/// the same units as the blended hybrid score: verified concepts gain a little,
+/// stale, deprecated, and draft concepts lose a little. Plain-Markdown
+/// documents are unaffected.
+fn metadata_adjustment(meta: Option<&OkfMeta>, stale: bool) -> f32 {
+    let Some(meta) = meta else {
+        return 0.0;
+    };
+    let mut adjustment: f32 = match meta.trust_tier {
+        TrustTier::HumanReviewed => 0.05,
+        TrustTier::MachineConfirmed => 0.02,
+        TrustTier::Unverified => 0.0,
+    };
+    if stale {
+        adjustment -= 0.10;
+    }
+    match meta.status.as_deref().unwrap_or("stable") {
+        "deprecated" => adjustment -= 0.10,
+        "draft" => adjustment -= 0.02,
+        _ => {}
+    }
+    adjustment.clamp(-0.25, 0.25)
 }
 
 fn matches_tag(tags: &[String], tag: &str) -> bool {
@@ -518,9 +648,112 @@ mod tests {
         );
         index.documents.insert(doc.doc_id.clone(), doc);
 
-        let hit = resolve_candidate(&index, "knowledge:docs/a.md#a-sub", Some("OPS"));
-        assert!(hit.is_some());
-        assert!(resolve_candidate(&index, "knowledge:docs/a.md#a-sub", Some("dev")).is_none());
+        let no_filter = DocFilter {
+            tag: None,
+            okf_type: None,
+            status: None,
+            min_trust: None,
+        };
+        let tag_filter = DocFilter {
+            tag: Some("OPS"),
+            ..no_filter
+        };
+        assert!(resolve_candidate(&index, "knowledge:docs/a.md#a-sub", &tag_filter).is_some());
+        let dev_filter = DocFilter {
+            tag: Some("dev"),
+            ..no_filter
+        };
+        assert!(resolve_candidate(&index, "knowledge:docs/a.md#a-sub", &dev_filter).is_none());
+    }
+
+    #[test]
+    fn okf_filters_exclude_plain_markdown_and_match_metadata() {
+        let mut index = crate::knowledge::KnowledgeIndex::default();
+        let okf_doc = document::parse_markdown(
+            "kb/revenue.md",
+            "---\ntype: Attested Computation\nstatus: stable\nverified: { by: human:ana, at: 2026-06-25T09:00:00Z }\n---\n# Computation\nSELECT 1\n",
+        );
+        let plain_doc = document::parse_markdown("notes.md", "Plain notes.\n");
+        index
+            .documents
+            .insert(okf_doc.doc_id.clone(), okf_doc.clone());
+        index.documents.insert(plain_doc.doc_id.clone(), plain_doc);
+
+        let base = DocFilter {
+            tag: None,
+            okf_type: None,
+            status: None,
+            min_trust: None,
+        };
+        let section_id = "knowledge:kb/revenue.md#computation";
+
+        let type_filter = DocFilter {
+            okf_type: Some("attested computation"),
+            ..base
+        };
+        assert!(resolve_candidate(&index, section_id, &type_filter).is_some());
+        // Plain Markdown documents never match OKF filters.
+        assert!(resolve_candidate(&index, "knowledge:notes.md#preamble", &type_filter).is_none());
+
+        let stale_filter = DocFilter {
+            status: Some("deprecated"),
+            ..base
+        };
+        assert!(resolve_candidate(&index, section_id, &stale_filter).is_none());
+
+        let human_only = DocFilter {
+            min_trust: Some(TrustTier::HumanReviewed),
+            ..base
+        };
+        assert!(resolve_candidate(&index, section_id, &human_only).is_some());
+        let machine_floor = DocFilter {
+            min_trust: Some(TrustTier::MachineConfirmed),
+            ..base
+        };
+        // Machine-confirmed floor also passes human-reviewed docs.
+        assert!(resolve_candidate(&index, section_id, &machine_floor).is_some());
+    }
+
+    #[test]
+    fn metadata_adjustment_follows_trust_and_lifecycle() {
+        assert_eq!(metadata_adjustment(None, false), 0.0);
+
+        let mut meta = OkfMeta {
+            doc_type: "Metric".into(),
+            ..Default::default()
+        };
+        assert_eq!(metadata_adjustment(Some(&meta), false), 0.0);
+
+        meta.trust_tier = TrustTier::HumanReviewed;
+        assert_eq!(metadata_adjustment(Some(&meta), false), 0.05);
+        // Stale verified doc: +0.05 − 0.10.
+        assert_eq!(metadata_adjustment(Some(&meta), true), -0.05);
+
+        meta.status = Some("deprecated".into());
+        assert_eq!(metadata_adjustment(Some(&meta), false), -0.05);
+
+        meta.status = Some("draft".into());
+        assert!((metadata_adjustment(Some(&meta), false) - 0.03).abs() < 1e-6);
+    }
+
+    #[test]
+    fn stale_metadata_is_reported_and_penalized() {
+        let mut index = crate::knowledge::KnowledgeIndex::default();
+        // stale_after far in the past.
+        let doc = document::parse_markdown(
+            "kb/old.md",
+            "---\ntype: Metric\nstale_after: 2000-01-01T00:00:00Z\n---\n# Metric\nBody.\n",
+        );
+        index.documents.insert(doc.doc_id.clone(), doc);
+        let base = DocFilter {
+            tag: None,
+            okf_type: None,
+            status: None,
+            min_trust: None,
+        };
+        let cand = resolve_candidate(&index, "knowledge:kb/old.md#metric", &base).unwrap();
+        assert!(cand.stale);
+        assert_eq!(cand.metadata_adjustment, -0.10);
     }
 
     #[tokio::test]
@@ -594,6 +827,9 @@ mod tests {
             tag: None,
             path_filter: Some("docs/".to_string()),
             limit: Some(5),
+            okf_type: None,
+            status: None,
+            min_trust: None,
             embed_config: None,
         };
         let response = search_knowledge(params).await.unwrap();
@@ -625,6 +861,9 @@ mod tests {
                         tag: None,
                         path_filter: None,
                         limit: Some(limit),
+                        okf_type: None,
+                        status: None,
+                        min_trust: None,
                         embed_config: None,
                     })
                     .await

--- a/tests/knowledge_okf.rs
+++ b/tests/knowledge_okf.rs
@@ -1,0 +1,343 @@
+//! Integration tests: OKF (Open Knowledge Format) knowledge indexing
+//! (Phase 2 of issue #118).
+//!
+//! Builds a representative OKF v0.2 bundle modeled on the spec's Appendix A
+//! worked example (metrics, attested computations in different trust/staleness
+//! states, cross-links, index.md/log.md reserved files) and exercises the
+//! `search_knowledge` MCP tool end to end over it.
+
+use serde_json::Value;
+
+// ── Representative OKF v0.2 bundle ─────────────────────────────────────────
+
+fn okf_bundle() -> Vec<(&'static str, &'static str)> {
+    vec![
+        (
+            "metrics/income-statement.md",
+            "---\ntype: Metric\ntitle: Income statement (fiscal year)\ndescription: Headline income-statement figures for a fiscal year.\ntags: [finance, income-statement]\nstatus: stable\ngenerated: { by: reference_agent/gemini-2.5-pro, at: 2026-06-20T22:53:05Z }\nverified: { by: human:ahormati, at: 2026-06-25T09:00:00Z }\nstale_after: 2026-12-31T00:00:00Z\nsources:\n  - id: fpa-handbook\n    resource: https://wiki.acme/finance/fpa-handbook\n    title: FP&A reporting handbook\n    author: team:finance-fpa\n---\n# Definition\n\nThe income statement reports [revenue](../computations/revenue.md) and\n[gross profit](../computations/profit.md) for a fiscal year, per the FP&A\nreporting handbook.[^fpa-handbook]\n\n[^fpa-handbook]: FP&A reporting handbook\n",
+        ),
+        (
+            "computations/revenue.md",
+            "---\ntype: Attested Computation\ntitle: Revenue for fiscal year\ndescription: Recognized revenue for a fiscal year, per Finance's definition.\ntags: [finance, revenue]\nstatus: stable\nruntime: bigquery\nexecutor:\n  resource: references/skills/run-on-bq.md\n  receipt: [job_id, executed_sql, result]\ngenerated: { by: reference_agent/gemini-2.5-pro, at: 2026-06-28T14:00:00Z }\nverified: { by: human:ahormati, at: 2026-06-25T09:00:00Z }\nstale_after: 2026-12-31T00:00:00Z\n---\n# Computation\n\n    SELECT SUM(amount) AS revenue\n    FROM finance.recognized_revenue\n    WHERE fiscal_year = @year\n",
+        ),
+        (
+            "computations/profit.md",
+            "---\ntype: Attested Computation\ntitle: Gross profit for fiscal year\ndescription: Gross profit by segment for a fiscal year.\ntags: [finance, profit]\nstatus: stable\nruntime: dbt\ngenerated: { by: reference_agent/gemini-2.5-pro, at: 2026-06-14T14:00:00Z }\nverified: { by: process:finance-nightly, at: 2026-06-12T08:00:00Z }\nstale_after: 2026-06-15T00:00:00Z\n---\n# Computation\n\n    SELECT gross_profit\n    FROM {{ ref('fct_income_statement') }}\n    WHERE fiscal_year = {{ var('year') }}\n",
+        ),
+        (
+            "computations/legacy-revenue.md",
+            "---\ntype: Attested Computation\ntitle: Legacy revenue estimate\ndescription: Superseded revenue estimate kept for history.\ntags: [finance, revenue]\nstatus: deprecated\ngenerated: { by: reference_agent/old-agent, at: 2025-01-01T00:00:00Z }\n---\n# Computation\n\n    SELECT SUM(amount) AS revenue\n    FROM finance.legacy_revenue\n",
+        ),
+        (
+            "draft-runbook.md",
+            "---\ntype: Playbook\ntitle: Revenue triage draft\ndescription: Draft steps for triaging revenue discrepancies.\nstatus: draft\ntags: [oncall]\n---\n# Steps\n\n1. Compare the attested revenue with the dashboard.\n",
+        ),
+        (
+            "plain-notes.md",
+            "Free-form notes with no front matter at all. Mentions revenue estimation.\n",
+        ),
+        // Reserved files: structural, indexed like any other Markdown.
+        (
+            "index.md",
+            "---\nokf_version: \"0.2\"\ntitle: Finance bundle\n---\n# Concepts\n\n* [Income statement](metrics/income-statement.md) - headline figures\n",
+        ),
+        (
+            "computations/index.md",
+            "# Computations\n\n* [Revenue](revenue.md) - recognized revenue\n* [Gross profit](profit.md) - gross profit by segment\n",
+        ),
+    ]
+}
+
+fn setup_project() -> (tempfile::TempDir, String) {
+    let dir = tempfile::TempDir::new().unwrap();
+    for (path, content) in okf_bundle() {
+        let full = dir.path().join(path);
+        std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+        std::fs::write(full, content).unwrap();
+    }
+    let project = dir.path().canonicalize().unwrap();
+    (dir, project.to_string_lossy().to_string())
+}
+
+fn results(response: &Value) -> &Vec<Value> {
+    response["results"].as_array().unwrap()
+}
+
+fn section_by_file<'a>(results: &'a [Value], path: &str) -> &'a Value {
+    results
+        .iter()
+        .find(|r| r["file_path"].as_str() == Some(path))
+        .unwrap_or_else(|| panic!("no result for {path}: {results:?}"))
+}
+
+// ── Metadata extraction over the bundle ────────────────────────────────────
+
+#[tokio::test]
+async fn okf_metadata_is_indexed_across_the_bundle() {
+    let (_dir, project) = setup_project();
+    let response = pitlane_mcp::tools::search_knowledge::search_knowledge(
+        pitlane_mcp::tools::search_knowledge::SearchKnowledgeParams {
+            project: project.clone(),
+            query: "fpa handbook fiscal year".into(),
+            tag: None,
+            path_filter: None,
+            okf_type: None,
+            status: None,
+            min_trust: None,
+            limit: Some(20),
+            embed_config: None,
+        },
+    )
+    .await
+    .unwrap();
+    let income = section_by_file(results(&response), "metrics/income-statement.md");
+    assert_eq!(income["okf_type"], "Metric");
+    assert_eq!(
+        income["description"],
+        "Headline income-statement figures for a fiscal year."
+    );
+    assert_eq!(income["trust_tier"], "human-reviewed");
+    assert_eq!(income["status"], "stable");
+    assert_eq!(income["stale"], false);
+
+    let related = income["related_docs"].as_array().unwrap();
+    let targets: Vec<&str> = related
+        .iter()
+        .filter_map(|l| l["target"].as_str())
+        .collect();
+    assert_eq!(
+        targets,
+        vec![
+            "computations/revenue.md".to_string(),
+            "computations/profit.md".to_string()
+        ]
+    );
+}
+
+#[tokio::test]
+async fn stale_and_deprecated_metadata_is_reported() {
+    let (_dir, project) = setup_project();
+    let response = pitlane_mcp::tools::search_knowledge::search_knowledge(
+        pitlane_mcp::tools::search_knowledge::SearchKnowledgeParams {
+            project: project.clone(),
+            query: "legacy revenue estimate".into(),
+            tag: None,
+            path_filter: None,
+            okf_type: None,
+            status: None,
+            min_trust: None,
+            limit: Some(10),
+            embed_config: None,
+        },
+    )
+    .await
+    .unwrap();
+    let legacy = section_by_file(results(&response), "computations/legacy-revenue.md");
+    assert_eq!(legacy["status"], "deprecated");
+    assert_eq!(legacy["trust_tier"], "unverified");
+    assert_eq!(legacy["metadata_adjustment"], -0.10);
+
+    let profit = pitlane_mcp::tools::search_knowledge::search_knowledge(
+        pitlane_mcp::tools::search_knowledge::SearchKnowledgeParams {
+            project: project.clone(),
+            query: "gross profit segment dbt".into(),
+            tag: None,
+            path_filter: None,
+            okf_type: None,
+            status: None,
+            min_trust: None,
+            limit: Some(10),
+            embed_config: None,
+        },
+    )
+    .await
+    .unwrap();
+    let profit_section = section_by_file(results(&profit), "computations/profit.md");
+    assert_eq!(profit_section["stale"], true);
+    assert_eq!(profit_section["trust_tier"], "machine-confirmed");
+    // Stale machine-confirmed: +0.02 − 0.10.
+    assert_eq!(profit_section["metadata_adjustment"], -0.08);
+}
+
+// ── Filters ────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn okf_type_filter_excludes_plain_markdown() {
+    let (_dir, project) = setup_project();
+    let response = pitlane_mcp::tools::search_knowledge::search_knowledge(
+        pitlane_mcp::tools::search_knowledge::SearchKnowledgeParams {
+            project: project.clone(),
+            query: "revenue".into(),
+            tag: None,
+            path_filter: None,
+            okf_type: Some("attested computation".into()),
+            status: None,
+            min_trust: None,
+            limit: Some(20),
+            embed_config: None,
+        },
+    )
+    .await
+    .unwrap();
+    // Every hit is an Attested Computation; the plain-notes doc is filtered out.
+    let files: Vec<&str> = results(&response)
+        .iter()
+        .filter_map(|r| r["file_path"].as_str())
+        .collect();
+    assert!(files.contains(&"computations/revenue.md"), "{files:?}");
+    assert!(
+        files.contains(&"computations/legacy-revenue.md"),
+        "{files:?}"
+    );
+    assert!(!files.contains(&"plain-notes.md"), "{files:?}");
+    assert!(!files.contains(&"index.md"), "{files:?}");
+}
+
+#[tokio::test]
+async fn status_filter_accepts_only_matching_lifecycle() {
+    let (_dir, project) = setup_project();
+    let response = pitlane_mcp::tools::search_knowledge::search_knowledge(
+        pitlane_mcp::tools::search_knowledge::SearchKnowledgeParams {
+            project: project.clone(),
+            query: "revenue".into(),
+            tag: None,
+            path_filter: None,
+            okf_type: None,
+            status: Some("deprecated".into()),
+            min_trust: None,
+            limit: Some(20),
+            embed_config: None,
+        },
+    )
+    .await
+    .unwrap();
+    let files: Vec<&str> = results(&response)
+        .iter()
+        .filter_map(|r| r["file_path"].as_str())
+        .collect();
+    assert_eq!(files, vec!["computations/legacy-revenue.md"]);
+}
+
+#[tokio::test]
+async fn min_trust_filter_requires_human_review_when_set() {
+    let (_dir, project) = setup_project();
+    let response = pitlane_mcp::tools::search_knowledge::search_knowledge(
+        pitlane_mcp::tools::search_knowledge::SearchKnowledgeParams {
+            project: project.clone(),
+            query: "revenue".into(),
+            tag: None,
+            path_filter: None,
+            okf_type: None,
+            status: None,
+            min_trust: Some("human-reviewed".into()),
+            limit: Some(20),
+            embed_config: None,
+        },
+    )
+    .await
+    .unwrap();
+    let files: Vec<&str> = results(&response)
+        .iter()
+        .filter_map(|r| r["file_path"].as_str())
+        .collect();
+    assert!(files.contains(&"metrics/income-statement.md"), "{files:?}");
+    // Legacy revenue is unverified; profit is machine-confirmed only.
+    assert!(
+        !files.contains(&"computations/legacy-revenue.md"),
+        "{files:?}"
+    );
+    assert!(!files.contains(&"computations/profit.md"), "{files:?}");
+}
+
+#[tokio::test]
+async fn invalid_min_trust_fails_fast() {
+    let (_dir, project) = setup_project();
+    let error = pitlane_mcp::tools::search_knowledge::search_knowledge(
+        pitlane_mcp::tools::search_knowledge::SearchKnowledgeParams {
+            project,
+            query: "revenue".into(),
+            tag: None,
+            path_filter: None,
+            okf_type: None,
+            status: None,
+            min_trust: Some("trust-me".into()),
+            limit: None,
+            embed_config: None,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(error.to_string().contains("min_trust"), "{error}");
+}
+
+// ── Ranking ────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn stable_verified_doc_outranks_identical_deprecated_doc() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let body = "# Computation\n\n    SELECT SUM(amount) AS revenue FROM finance.revenue\n";
+    // Same heading and body; only trust/lifecycle metadata differs, so the
+    // BM25 scores tie and the metadata adjustment decides the order.
+    std::fs::write(
+        dir.path().join("stable.md"),
+        format!(
+            "---\ntype: Attested Computation\nverified: {{ by: human:ana, at: 2026-06-25T09:00:00Z }}\n---\n{body}"
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("deprecated.md"),
+        format!("---\ntype: Attested Computation\nstatus: deprecated\nstale_after: 2000-01-01T00:00:00Z\n---\n{body}"),
+    )
+    .unwrap();
+
+    let response = pitlane_mcp::tools::search_knowledge::search_knowledge(
+        pitlane_mcp::tools::search_knowledge::SearchKnowledgeParams {
+            project: dir
+                .path()
+                .canonicalize()
+                .unwrap()
+                .to_string_lossy()
+                .to_string(),
+            query: "revenue computation".into(),
+            tag: None,
+            path_filter: None,
+            okf_type: None,
+            status: None,
+            min_trust: None,
+            limit: Some(5),
+            embed_config: None,
+        },
+    )
+    .await
+    .unwrap();
+    let files: Vec<&str> = results(&response)
+        .iter()
+        .filter_map(|r| r["file_path"].as_str())
+        .collect();
+    assert_eq!(files.first(), Some(&"stable.md"), "{files:?}");
+}
+
+#[tokio::test]
+async fn reserved_files_are_indexed_with_okf_version() {
+    let (_dir, project) = setup_project();
+    let response = pitlane_mcp::tools::search_knowledge::search_knowledge(
+        pitlane_mcp::tools::search_knowledge::SearchKnowledgeParams {
+            project,
+            query: "finance bundle concepts".into(),
+            tag: None,
+            path_filter: None,
+            okf_type: None,
+            status: None,
+            min_trust: None,
+            limit: Some(5),
+            embed_config: None,
+        },
+    )
+    .await
+    .unwrap();
+    let index = section_by_file(results(&response), "index.md");
+    // `okf_version` is extracted; a doc without `type` is still non-OKF.
+    assert_eq!(index["okf_type"], Value::Null);
+    assert_eq!(index["trust_tier"], Value::Null);
+}


### PR DESCRIPTION
Phase 2 of #118 (stacked on the Phase 1 branch — merge it first).

Implements **OKF-aware indexing** per the [OKF v0.2 spec](https://github.com/GoogleCloudPlatform/open-knowledge-format):

## What's included

### OKF metadata extraction (5a40907)
- `src/knowledge/okf.rs` (new): typed `OkfMeta` — `type`, `description`, `resource`, `status`, trust tier derived from `verified` (spec §5.3, bare mapping = one-event list), `stale_after`, `sources` with credibility signals (`author`, `usage_count`, `last_modified`), `usage_window`, `okf_version`
- Front matter is now parsed with full YAML (`serde_yaml`), replacing the Phase 1 minimal subset; nested fields like `generated: { by, at }` and `sources:` entries parse correctly
- Unknown front-matter keys (including OKF computation fields such as `runtime`) are preserved in the generic metadata bag; malformed front matter falls back to plain Markdown (lenient per spec §11)
- Document relationships: `src/knowledge/links.rs` (new) — markdown links resolved to normalized project-relative `.md` targets (bundle-relative `/x.md` and relative `./x.md` forms); external URLs/anchors/code ignored; broken links tolerated per spec §6
- Persisted layout bumped to `KNOWLEDGE_META_VERSION 2`

### Metadata-aware filtering and ranking (8d8f058)
- New `search_knowledge` filters: `okf_type`, `status` (`draft`/`stable`/`deprecated`), `min_trust` (`unverified` < `machine-confirmed` < `human-reviewed`); OKF filters never match plain-Markdown documents, invalid `min_trust` fails fast
- Results expose `okf_type`, `description`, `resource`, `status`, `trust_tier`, `stale`, `metadata_adjustment`, and `related_docs`
- Advisory ranking adjustments: +0.05 human-reviewed, +0.02 machine-confirmed, −0.10 stale, −0.10 deprecated, −0.02 draft (plain Markdown unaffected)

### Representative OKF fixture + tests (1b78e17, c309d39)
- `tests/knowledge_okf.rs`: bundle modeled on the spec's Appendix A worked example (metrics, attested computations in different trust/staleness states, cross-links, `index.md`/`log.md` reserved files) — 8 end-to-end tests
- Fix: the lexical-only ranking path re-sorts after metadata adjustment

## Test results
- `cargo test --lib`: 740 passed
- `cargo test --test knowledge_okf`: 8 passed
- clippy `-D warnings` clean, fmt clean

## Docs
`docs/tools.md`, `README.md`, `AGENTS.md`, and `AGENT_HANDOFF.md` updated.