### PR TITLE
feat(knowledge): read_knowledge_document for full-document/section retrieval (Phase 3, #118)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ Default public tier:
 - `doctor`
 - `search_content`
 - `search_knowledge`
+- `read_knowledge_document`
 
 Advanced primitive tools are hidden from `tools/list` unless the server is started with `PITLANE_MCP_TOOL_TIER=all`.
 
@@ -34,13 +35,14 @@ Advanced primitive tools are hidden from `tools/list` unless the server is start
 5. Use `analyze_impact` for blast-radius questions before edits or refactors. Use `analyze_changes` to map a Git diff to revision-qualified symbols, impact evidence, and test candidates.
 6. Use `search_content` when you know a text snippet, log string, import path, macro name, or regex fragment but do not know the symbol boundary yet.
 7. Use `search_knowledge` for documentation questions — it searches indexed Markdown (docs, READMEs, runbooks) by heading and content, with hybrid lexical/semantic ranking when embeddings exist. It understands OKF v0.2 documents natively: filter by concept `type`/`status`/trust tier via `okf_type`/`status`/`min_trust`, and results carry trust, staleness, and cross-document `related_docs` relationships.
-7. Use `get_index_stats` to orient yourself in unfamiliar repos before broader exploration.
-8. Fall back to direct file reads only when editing or when full-file context is genuinely required.
-9. Treat `read_code_unit` as the preferred diff-aware read surface. Use its `read_state.status` field to decide whether to reuse the payload, expand, or reread:
+8. Use `read_knowledge_document` to open a document found by `search_knowledge`: the full source Markdown by default, or one section via `section` (a `sections[].section_id` slug or the full `section_id`). Results include OKF metadata, the section outline with line ranges, and the link graph (`related_docs` outgoing, `referenced_by` incoming).
+9. Use `get_index_stats` to orient yourself in unfamiliar repos before broader exploration.
+10. Fall back to direct file reads only when editing or when full-file context is genuinely required.
+11. Treat `read_code_unit` as the preferred diff-aware read surface. Use its `read_state.status` field to decide whether to reuse the payload, expand, or reread:
    `new` means first read in this session
    `unchanged` means the same target was reread with identical content, so expand instead of rereading again
    `changed` means the same target changed since the previous read, so use the refreshed payload before expanding
-10. When `locate_code`, `trace_path`, or `analyze_impact` return `session_state`, use it to understand whether the top target was already seen and whether the server intentionally promoted an unseen nearby alternative.
+12. When `locate_code`, `trace_path`, or `analyze_impact` return `session_state`, use it to understand whether the top target was already seen and whether the server intentionally promoted an unseen nearby alternative.
 
 # Search Strategy
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Most users should stay on the default tool tier:
 6. Use `analyze_impact` before edits or refactors, and `analyze_changes` to review a Git diff.
 7. Use `search_content` only when you know a text fragment but not the owning symbol.
 8. Use `search_knowledge` for documentation questions — it searches indexed Markdown (docs, READMEs, runbooks) by heading and content. It understands OKF v0.2 documents natively (`okf_type`/`status`/`min_trust` filters; results carry trust tier, staleness, and related-document links).
+9. Use `read_knowledge_document` to open a document found by `search_knowledge` — the full source Markdown by default, or one section via `section`. Results include OKF metadata, the section outline with line ranges, and `related_docs`/`referenced_by` links.
 
 Default public tier:
 
@@ -160,6 +161,7 @@ Default public tier:
 - `get_index_stats`
 - `search_content`
 - `search_knowledge`
+- `read_knowledge_document`
 
 Advanced primitives are hidden from `tools/list` by default. Set `PITLANE_MCP_TOOL_TIER=all` to expose the full surface.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -215,10 +215,29 @@ Notes:
 - The index is built lazily on first use. Each search hashes eligible Markdown files to catch edits even when timestamps and sizes are preserved; only changed documents are reparsed.
 - Ranking blends BM25 over section text/headings with semantic cosine similarity when `PITLANE_EMBED_URL`/`PITLANE_EMBED_MODEL` are set. Section embeddings generate in the background after changes; lexical results are always available without them.
 - Optional filters: `tag` (document front-matter tag, case-insensitive), `path_filter` (substring of the relative file path), and OKF metadata filters: `okf_type` (front-matter `type`, case-insensitive), `status` (`draft`/`stable`/`deprecated`), and `min_trust` (`unverified` < `machine-confirmed` < `human-reviewed`). OKF filters only match documents that carry OKF metadata.
-- Results include `file_path`, heading hierarchy, line range, a snippet, and score breakdown — open full sections with `read_code_unit` using those coordinates.
+- Results include `file_path`, heading hierarchy, line range, a snippet, and score breakdown — open the full document with `read_knowledge_document`, or pass a result's `section_id` to fetch only that section.
 - [Open Knowledge Format](https://github.com/GoogleCloudPlatform/open-knowledge-format) (OKF) v0.2 documents are understood natively: front matter is parsed as full YAML, and `type`/`description`/`resource`/`status`/`generated`/`verified`/`stale_after`/`sources` metadata is extracted, filtered on, and returned with each result. The derived trust tier (`verified` by `human:` actors ⇒ human-reviewed) and staleness (`stale_after` passed) are advisory ranking signals: verified concepts rank slightly higher, stale/deprecated/draft concepts slightly lower. Plain-Markdown documents remain fully usable without OKF metadata.
 - Markdown links to other knowledge documents (bundle-relative `/x.md` or relative `./x.md`) are preserved as `related_docs` in results, exposing the bundle's relationship graph.
 - Unknown front-matter keys (including OKF extension and computation fields such as `runtime`) are preserved in the index and available for future use; malformed front matter is treated as plain Markdown.
+
+### `read_knowledge_document`
+
+Read the full source Markdown of an indexed knowledge document, or one section's
+exact line range, after `search_knowledge` returns a snippet.
+
+```json
+{ "project": "/your/project", "document": "docs/runbooks/retries.md" }
+```
+
+Pass `"section"` to fetch only one part: a `sections[].section_id` slug (e.g.
+`retries-backoff`), `preamble`, or a full section id
+(`knowledge:docs/retries.md#retries-backoff`).
+
+Notes:
+
+- The source Markdown stays authoritative; the tool serves it from disk, refreshing the index first under the same lock, so the text always matches the reported section coordinates.
+- Responses include title/tags, OKF metadata (`okf_type`, `description`, `resource`, `status`, `trust_tier`, `stale`), the parsed `front_matter` bag, a section outline with line ranges, and the link graph: `related_docs` (outgoing links) and `referenced_by` (documents linking in).
+- Unindexed or non-Markdown paths fail with `DOCUMENT_NOT_FOUND`; unknown sections fail with `INVALID_ARGUMENT` listing the available ids; paths outside the project (including `../` traversal and absolute paths) are rejected with `ACCESS_DENIED`.
 
 ### `search_content`
 

--- a/src/bin/pitlane.rs
+++ b/src/bin/pitlane.rs
@@ -278,6 +278,42 @@ enum Command {
         #[arg(long)]
         include_tests: bool,
     },
+    /// Search the project's Markdown knowledge base (docs, READMEs, runbooks)
+    SearchKnowledge {
+        /// Path to the indexed project
+        project: String,
+        /// Natural-language query describing the information need
+        query: String,
+        /// Document-level tag filter from front matter (`tags`/`categories`)
+        #[arg(long)]
+        tag: Option<String>,
+        /// Substring filter on relative file paths (e.g. "docs/runbooks")
+        #[arg(long = "path-filter", value_name = "SUBSTR")]
+        path_filter: Option<String>,
+        /// OKF concept-type filter (front matter `type`, e.g. "Playbook")
+        #[arg(long = "okf-type", value_name = "TYPE")]
+        okf_type: Option<String>,
+        /// OKF lifecycle filter: draft, stable, or deprecated
+        #[arg(long)]
+        status: Option<String>,
+        /// Minimum OKF trust tier: unverified, machine-confirmed, or human-reviewed
+        #[arg(long = "min-trust", value_name = "TIER")]
+        min_trust: Option<String>,
+        /// Maximum number of sections to return (default: 8, max: 50)
+        #[arg(long, default_value_t = 8)]
+        limit: usize,
+    },
+    /// Read the full source Markdown of an indexed knowledge document, or one section
+    ReadKnowledgeDocument {
+        /// Path to the indexed project
+        project: String,
+        /// Project-relative Markdown path (from search-knowledge `file_path`)
+        document: String,
+        /// Section to read instead of the whole document: a `sections[].section_id`
+        /// slug, "preamble", or a full section id ("knowledge:docs/x.md#slug")
+        #[arg(long)]
+        section: Option<String>,
+    },
 }
 
 fn embeddings_count_in_store(path: &std::path::Path) -> usize {
@@ -686,6 +722,72 @@ async fn run_command(command: Command) -> anyhow::Result<serde_json::Value> {
             };
             tools::investigate::investigate(params).await?
         }
+
+        Command::SearchKnowledge {
+            project,
+            query,
+            tag,
+            path_filter,
+            okf_type,
+            status,
+            min_trust,
+            limit,
+        } => {
+            let embed_config = pitlane_mcp::embed::EmbedConfig::try_from_env()?.map(Arc::new);
+
+            // One-shot process: background embedding tasks would die with the
+            // CLI (same reason `index` passes embed_config=None and embeds
+            // synchronously). Refresh the index, regenerate embeddings inline
+            // when the store is missing or stale, then search — so semantic
+            // ranking works instead of silently degrading to lexical-only.
+            if let Some(cfg) = embed_config.as_ref() {
+                let canonical = resolve_project_path(&project)?;
+                let (changed, index) = pitlane_mcp::knowledge::ensure_knowledge_index(&canonical)?;
+                if changed
+                    || !tools::search_knowledge::knowledge_store_fresh(&canonical, &index, cfg)
+                {
+                    let docs: Vec<pitlane_mcp::knowledge::document::KnowledgeDocument> =
+                        index.documents.values().cloned().collect();
+                    let store_path = pitlane_mcp::index::format::knowledge_dir(&canonical)?
+                        .join("embeddings.bin");
+                    let result = pitlane_mcp::knowledge::generate_knowledge_embeddings(
+                        &docs,
+                        cfg,
+                        &store_path,
+                    )
+                    .await;
+                    if let Some(err) = result.error {
+                        eprintln!("warning: knowledge embedding generation failed: {err}");
+                    }
+                }
+            }
+
+            let params = tools::search_knowledge::SearchKnowledgeParams {
+                project,
+                query,
+                tag,
+                path_filter,
+                okf_type,
+                status,
+                min_trust,
+                limit: Some(limit),
+                embed_config,
+            };
+            tools::search_knowledge::search_knowledge(params).await?
+        }
+
+        Command::ReadKnowledgeDocument {
+            project,
+            document,
+            section,
+        } => {
+            let params = tools::read_knowledge_document::ReadKnowledgeDocumentParams {
+                project,
+                document,
+                section,
+            };
+            tools::read_knowledge_document::read_knowledge_document(params).await?
+        }
     };
     Ok(result)
 }
@@ -825,6 +927,169 @@ mod tests {
             }
             other => panic!("unexpected command: {other:?}"),
         }
+    }
+
+    #[test]
+    fn clap_parses_search_knowledge_command() {
+        let cli = Cli::try_parse_from([
+            "pitlane",
+            "search-knowledge",
+            "/tmp/kb",
+            "retry backoff",
+            "--tag",
+            "ops",
+            "--path-filter",
+            "docs/",
+            "--okf-type",
+            "Playbook",
+            "--status",
+            "stable",
+            "--min-trust",
+            "human-reviewed",
+            "--limit",
+            "5",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Command::SearchKnowledge {
+                project,
+                query,
+                tag,
+                path_filter,
+                okf_type,
+                status,
+                min_trust,
+                limit,
+            } => {
+                assert_eq!(project, "/tmp/kb");
+                assert_eq!(query, "retry backoff");
+                assert_eq!(tag.as_deref(), Some("ops"));
+                assert_eq!(path_filter.as_deref(), Some("docs/"));
+                assert_eq!(okf_type.as_deref(), Some("Playbook"));
+                assert_eq!(status.as_deref(), Some("stable"));
+                assert_eq!(min_trust.as_deref(), Some("human-reviewed"));
+                assert_eq!(limit, 5);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn clap_parses_read_knowledge_document_command() {
+        let cli = Cli::try_parse_from([
+            "pitlane",
+            "read-knowledge-document",
+            "/tmp/kb",
+            "docs/guide.md",
+            "--section",
+            "guide-backoff",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Command::ReadKnowledgeDocument {
+                project,
+                document,
+                section,
+            } => {
+                assert_eq!(project, "/tmp/kb");
+                assert_eq!(document, "docs/guide.md");
+                assert_eq!(section.as_deref(), Some("guide-backoff"));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+
+        // Section is optional: whole-document read by default.
+        let cli = Cli::try_parse_from([
+            "pitlane",
+            "read-knowledge-document",
+            "/tmp/kb",
+            "docs/guide.md",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::ReadKnowledgeDocument { section, .. } => assert_eq!(section, None),
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_command_search_knowledge_finds_and_filters_sections() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("guide.md"),
+            "# Retry policy\nExponential backoff with jitter.\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(dir.path().join("docs")).unwrap();
+        std::fs::write(
+            dir.path().join("docs/other.md"),
+            "# Other\nUnrelated body text.\n",
+        )
+        .unwrap();
+
+        let result = run_command(Command::SearchKnowledge {
+            project: dir.path().to_string_lossy().to_string(),
+            query: "retry backoff".to_string(),
+            tag: None,
+            path_filter: None,
+            okf_type: None,
+            status: None,
+            min_trust: None,
+            limit: 8,
+        })
+        .await
+        .unwrap();
+        assert_eq!(result["results_count"], 1);
+        assert_eq!(result["results"][0]["file_path"], "guide.md");
+
+        // The path filter narrows matching to docs/.
+        let result = run_command(Command::SearchKnowledge {
+            project: dir.path().to_string_lossy().to_string(),
+            query: "unrelated body".to_string(),
+            tag: None,
+            path_filter: Some("docs/".to_string()),
+            okf_type: None,
+            status: None,
+            min_trust: None,
+            limit: 8,
+        })
+        .await
+        .unwrap();
+        assert_eq!(result["results_count"], 1);
+        assert_eq!(result["results"][0]["file_path"], "docs/other.md");
+    }
+
+    #[tokio::test]
+    async fn run_command_read_knowledge_document_serves_source_and_section() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("guide.md"),
+            "# Guide\nIntro.\n## Backoff\nUse jitter.\n",
+        )
+        .unwrap();
+
+        let result = run_command(Command::ReadKnowledgeDocument {
+            project: dir.path().to_string_lossy().to_string(),
+            document: "guide.md".to_string(),
+            section: None,
+        })
+        .await
+        .unwrap();
+        assert_eq!(
+            result["content"],
+            "# Guide\nIntro.\n## Backoff\nUse jitter.\n"
+        );
+
+        let result = run_command(Command::ReadKnowledgeDocument {
+            project: dir.path().to_string_lossy().to_string(),
+            document: "guide.md".to_string(),
+            section: Some("guide-backoff".to_string()),
+        })
+        .await
+        .unwrap();
+        assert_eq!(result["section"]["content"], "## Backoff\nUse jitter.");
     }
 
     #[tokio::test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,8 @@ pub enum ToolError {
     IndexingInProgress { project: String },
     /// The requested path is outside the configured allowed roots or project root.
     AccessDenied { path: String },
+    /// The requested knowledge document is not in the knowledge index.
+    DocumentNotFound { path: String },
     /// Catch-all for unexpected I/O or internal failures.
     Internal { message: String },
 }
@@ -39,6 +41,7 @@ impl ToolError {
             ToolError::FileLimitExceeded { .. } => "FILE_LIMIT_EXCEEDED",
             ToolError::IndexingInProgress { .. } => "INDEXING_IN_PROGRESS",
             ToolError::AccessDenied { .. } => "ACCESS_DENIED",
+            ToolError::DocumentNotFound { .. } => "DOCUMENT_NOT_FOUND",
             ToolError::Internal { .. } => "INTERNAL_ERROR",
         }
     }
@@ -60,6 +63,9 @@ impl ToolError {
             }
             ToolError::AccessDenied { .. } => {
                 "Check PITLANE_ALLOWED_ROOTS and keep file paths inside the indexed project root."
+            }
+            ToolError::DocumentNotFound { .. } => {
+                "Use search_knowledge to discover indexed documents and their section ids; only .md/.markdown files inside the project that are not excluded are indexed."
             }
             ToolError::Internal { .. } => "Check the project path and try again.",
         }
@@ -103,6 +109,10 @@ impl std::fmt::Display for ToolError {
                 f,
                 "Access to '{}' is denied by the current path policy.",
                 path
+            ),
+            ToolError::DocumentNotFound { path } => write!(
+                f,
+                "Knowledge document '{path}' is not in the knowledge index."
             ),
             ToolError::Internal { message } => write!(f, "{}", message),
         }
@@ -160,6 +170,16 @@ mod tests {
         assert_eq!(e.code(), "ACCESS_DENIED");
         assert!(e.hint().contains("PITLANE_ALLOWED_ROOTS"));
         assert!(e.to_string().contains("/tmp/secret.rs"));
+    }
+
+    #[test]
+    fn test_document_not_found_code_and_hint() {
+        let e = ToolError::DocumentNotFound {
+            path: "docs/gone.md".to_string(),
+        };
+        assert_eq!(e.code(), "DOCUMENT_NOT_FOUND");
+        assert!(e.hint().contains("search_knowledge"));
+        assert!(e.to_string().contains("docs/gone.md"));
     }
 
     #[test]
@@ -234,6 +254,9 @@ mod tests {
             },
             ToolError::AccessDenied {
                 path: "/tmp/blocked".to_string(),
+            },
+            ToolError::DocumentNotFound {
+                path: "docs/gone.md".to_string(),
             },
             ToolError::Internal {
                 message: "oops".to_string(),

--- a/src/knowledge/okf.rs
+++ b/src/knowledge/okf.rs
@@ -87,7 +87,8 @@ pub struct OkfMeta {
     pub resource: Option<String>,
     /// `status`: `draft` | `stable` | `deprecated`; absent ⇒ `stable`.
     pub status: Option<String>,
-    /// `stale_after` as a raw ISO 8601 datetime string.
+    /// `stale_after` raw value: the spec §5.5 date-only `YYYY-MM-DD`
+    /// spelling, or a full RFC 3339 timestamp.
     pub stale_after: Option<String>,
     pub trust_tier: TrustTier,
     pub generated_by: Option<String>,
@@ -147,8 +148,11 @@ pub fn extract_okf(front_matter: &serde_yaml::Value) -> Option<OkfMeta> {
     })
 }
 
-/// True when the document's `stale_after` instant is at or before `now_secs`.
-/// Malformed timestamps are never stale.
+/// True when the document's `stale_after` (spec §5.5) has passed: a full RFC
+/// 3339 instant, or the spec's bare `YYYY-MM-DD` date. Date-only values are
+/// compared from UTC midnight of that day, so a concept is stale on/after its
+/// `stale_after` day itself — matching the reference implementation's
+/// `today >= stale_after`. Malformed values are never stale.
 pub fn is_stale(meta: &OkfMeta, now_secs: i64) -> bool {
     meta.stale_after
         .as_deref()
@@ -156,11 +160,39 @@ pub fn is_stale(meta: &OkfMeta, now_secs: i64) -> bool {
         .is_some_and(|t| now_secs >= t)
 }
 
-/// Parse an ISO 8601 datetime with explicit offset into Unix seconds.
+/// Parse a `stale_after` value into Unix seconds: a full RFC 3339 datetime
+/// with explicit offset, or the OKF spec §5.5 date-only `YYYY-MM-DD` spelling
+/// (as UTC midnight, so a concept is stale from the start of that day).
+/// Returns `None` for anything else, including the basic (`20260101`) and
+/// week (`2026-W01-1`) forms the okf reference's strict ISO_DATE grammar
+/// rejects.
 pub fn parse_iso8601_secs(s: &str) -> Option<i64> {
-    chrono::DateTime::parse_from_rfc3339(s.trim())
-        .ok()
-        .map(|dt| dt.timestamp())
+    let s = s.trim();
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
+        return Some(dt.timestamp());
+    }
+    // Strict `YYYY-MM-DD`: exactly four digits, dash, two digits, dash, two
+    // digits. `from_ymd_opt` then validates calendar legality (month and day
+    // ranges, leap years).
+    let bytes = s.as_bytes();
+    if bytes.len() != 10
+        || !bytes[..4].iter().all(|b| b.is_ascii_digit())
+        || bytes[4] != b'-'
+        || !bytes[5..7].iter().all(|b| b.is_ascii_digit())
+        || bytes[7] != b'-'
+        || !bytes[8..].iter().all(|b| b.is_ascii_digit())
+    {
+        return None;
+    }
+    let year = std::str::from_utf8(&bytes[..4]).ok()?.parse::<i32>().ok()?;
+    let month = std::str::from_utf8(&bytes[5..7])
+        .ok()?
+        .parse::<u32>()
+        .ok()?;
+    let day = std::str::from_utf8(&bytes[8..]).ok()?.parse::<u32>().ok()?;
+    chrono::NaiveDate::from_ymd_opt(year, month, day)
+        .and_then(|d| d.and_hms_opt(0, 0, 0))
+        .map(|dt| dt.and_utc().timestamp())
 }
 
 /// Current time as Unix seconds (0 on clock failure, matching FileState).
@@ -347,6 +379,72 @@ mod tests {
 
         meta.stale_after = None;
         assert!(!is_stale(&meta, i64::MAX / 2));
+    }
+
+    #[test]
+    fn stale_after_date_only_spelling_is_stale_from_that_day() {
+        // Spec §5.5 names the bare date; a concept is stale on/after the day.
+        let far_past = OkfMeta {
+            doc_type: "Metric".into(),
+            stale_after: Some("2000-01-01".into()),
+            ..Default::default()
+        };
+        assert!(is_stale(
+            &far_past,
+            parse_iso8601_secs("2026-09-23T12:00:00Z").unwrap()
+        ));
+
+        // Boundary: on the cut-off day itself (UTC midnight) the doc is stale.
+        let today = OkfMeta {
+            doc_type: "Metric".into(),
+            stale_after: Some("2026-09-23".into()),
+            ..Default::default()
+        };
+        assert!(is_stale(
+            &today,
+            parse_iso8601_secs("2026-09-23T00:00:00Z").unwrap()
+        ));
+
+        // Date-only and its RFC 3339 midnight equate to the same instant.
+        assert_eq!(
+            parse_iso8601_secs("2000-01-01"),
+            parse_iso8601_secs("2000-01-01T00:00:00Z")
+        );
+
+        // A future cut-off is not stale yet.
+        let future = OkfMeta {
+            doc_type: "Metric".into(),
+            stale_after: Some("2099-12-31".into()),
+            ..Default::default()
+        };
+        assert!(!is_stale(
+            &future,
+            parse_iso8601_secs("2026-09-23T12:00:00Z").unwrap()
+        ));
+    }
+
+    #[test]
+    fn stale_after_rejects_non_date_spellings() {
+        // Basic and week forms (rejected by the reference's ISO_DATE too),
+        // non-padded parts, impossible dates, and garbage.
+        for bad in [
+            "20260101",
+            "2026-W01-1",
+            "2026-1-1",
+            "2026-09-1",
+            "2026-13-01",
+            "2026-00-01",
+            "2026-09-32",
+            "2026-02-30",
+            "2026-09-23 00:00:00",
+            "not a date",
+            "",
+        ] {
+            assert_eq!(parse_iso8601_secs(bad), None, "expected {bad:?} rejected");
+        }
+        // Full RFC 3339 timestamps still parse through the timestamp path.
+        assert!(parse_iso8601_secs("2026-09-23T00:00:00Z").is_some());
+        assert!(parse_iso8601_secs("2026-09-23T12:30:00-05:00").is_some());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,6 +172,7 @@ project_field!(
     FindUsagesRequest => canonical = "project", alias = "path";
     WatchProjectRequest => canonical = "project", alias = "path";
     SearchKnowledgeRequest => canonical = "project", alias = "path";
+    ReadKnowledgeDocumentRequest => canonical = "project", alias = "path";
     GetIndexStatsRequest => canonical = "project", alias = "path";
     DoctorRequest => canonical = "project", alias = "path";
     GetIndexChangesRequest => canonical = "project", alias = "path";
@@ -234,6 +235,17 @@ pub struct SearchKnowledgeRequest {
     pub min_trust: Option<String>,
     /// Maximum number of sections to return (default 8, max 50).
     pub limit: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct ReadKnowledgeDocumentRequest {
+    /// Path to an indexed project. The MCP field `path` is accepted as an alias.
+    #[serde(alias = "path")]
+    pub project: String,
+    /// Project-relative Markdown path of the document, as returned by search_knowledge (`file_path`), e.g. "docs/runbooks/retries.md".
+    pub document: String,
+    /// Optional section to read instead of the whole document: a `sections[].section_id` slug (e.g. "retry-policy"), "preamble", or a full section id ("knowledge:docs/x.md#retry-policy").
+    pub section: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
@@ -636,6 +648,7 @@ const DEFAULT_PUBLIC_TOOL_NAMES: &[&str] = &[
     "doctor",
     "search_content",
     "search_knowledge",
+    "read_knowledge_document",
 ];
 
 const ADVANCED_TOOL_NAMES: &[&str] = &[
@@ -1028,7 +1041,7 @@ impl PitlaneMcp {
     }
 
     #[tool(
-        description = "Search the project's Markdown knowledge base (docs/README/runbooks) by heading and content with lexical + semantic ranking when embeddings exist; OKF metadata (type/status/trust tier) can be used for filtering. Prefer this for documentation questions; use read_code_unit on a result to open the full section.",
+        description = "Search the project's Markdown knowledge base (docs/README/runbooks) by heading and content with lexical + semantic ranking when embeddings exist; OKF metadata (type/status/trust tier) can be used for filtering. Prefer this for documentation questions; use read_knowledge_document on a result to open the full document or section.",
         meta = tool_meta("search docs documentation markdown knowledge readme runbook"),
         annotations(
             read_only_hint = true,
@@ -1053,6 +1066,31 @@ impl PitlaneMcp {
             embed_config: self.embed_config.clone(),
         };
         match tools::search_knowledge::search_knowledge(params).await {
+            Ok(v) => value_to_text(v),
+            Err(e) => err_to_text(e),
+        }
+    }
+
+    #[tool(
+        description = "Read the full source Markdown of an indexed knowledge document, or one section by id, after search_knowledge returns a snippet. Returns the authoritative document text plus OKF metadata, the section outline with line coordinates, and the document link graph (related_docs/referenced_by).",
+        meta = tool_meta("read knowledge document section markdown docs full source open"),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn read_knowledge_document(
+        &self,
+        Parameters(Friendly(req)): Parameters<Friendly<ReadKnowledgeDocumentRequest>>,
+    ) -> String {
+        let params = tools::read_knowledge_document::ReadKnowledgeDocumentParams {
+            project: req.project,
+            document: req.document,
+            section: req.section,
+        };
+        match tools::read_knowledge_document::read_knowledge_document(params).await {
             Ok(v) => value_to_text(v),
             Err(e) => err_to_text(e),
         }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -15,6 +15,7 @@ pub mod index_changes;
 pub mod index_project;
 pub mod investigate;
 pub mod orchestrator;
+pub mod read_knowledge_document;
 pub mod search_content;
 pub mod search_files;
 pub mod search_knowledge;

--- a/src/tools/read_knowledge_document.rs
+++ b/src/tools/read_knowledge_document.rs
@@ -284,7 +284,7 @@ fn section_id_list(doc: &KnowledgeDocument) -> String {
 fn served_reason(doc: &KnowledgeDocument, stale: bool, what: &str) -> String {
     let mut reason = format!("Served {what} of '{}'.", doc.title);
     if stale {
-        reason.push_str(" Warning: the document is stale (its `stale_after` instant has passed).");
+        reason.push_str(" Warning: the document is stale (its `stale_after` date has passed).");
     }
     reason
 }
@@ -476,18 +476,30 @@ mod tests {
     #[tokio::test]
     async fn stale_okf_documents_are_flagged() {
         let dir = TempDir::new().unwrap();
+        // Full RFC 3339 spelling.
         std::fs::write(
             dir.path().join("old.md"),
             "---\ntype: Metric\nstale_after: 2000-01-01T00:00:00Z\n---\n# Old\nBody.\n",
         )
         .unwrap();
+        // Spec §5.5 date-only spelling must be flagged too.
+        std::fs::write(
+            dir.path().join("old-date.md"),
+            "---\ntype: Metric\nstale_after: 2000-01-01\n---\n# Old\nBody.\n",
+        )
+        .unwrap();
         let root = dir.path().canonicalize().unwrap();
 
-        let response = read(&root, "old.md", Some("old")).await.unwrap();
-        assert_eq!(response["stale"], true);
-        assert!(response["steering"]["why_this_matched"]
-            .as_str()
-            .unwrap()
-            .contains("stale"));
+        for file in ["old.md", "old-date.md"] {
+            let response = read(&root, file, Some("old")).await.unwrap();
+            assert_eq!(response["stale"], true, "{file} should be stale");
+            assert!(
+                response["steering"]["why_this_matched"]
+                    .as_str()
+                    .unwrap()
+                    .contains("stale"),
+                "{file}"
+            );
+        }
     }
 }

--- a/src/tools/read_knowledge_document.rs
+++ b/src/tools/read_knowledge_document.rs
@@ -1,0 +1,493 @@
+//! Full-document and section retrieval over the indexed knowledge base
+//! (Phase 3 of issue #118).
+//!
+//! `search_knowledge` returns short snippets; this tool serves the
+//! authoritative Markdown source afterwards — the whole file, or one
+//! section's exact line range — plus document metadata, the section outline,
+//! and the cross-document link graph. The raw read happens under the same
+//! project lock as the incremental re-index, so the served text always
+//! matches the parsed section coordinates.
+
+use std::path::Path;
+
+use serde_json::{json, Map, Value};
+
+use crate::error::ToolError;
+use crate::knowledge::document::{KnowledgeDocument, KnowledgeSection};
+use crate::knowledge::{okf, with_knowledge_index};
+use crate::path_policy::{read_regular_file, resolve_project_file, resolve_project_path};
+use crate::tools::steering::{attach_steering, build_steering};
+
+pub struct ReadKnowledgeDocumentParams {
+    pub project: String,
+    /// Project-relative Markdown path, as returned by `search_knowledge`
+    /// (`file_path`).
+    pub document: String,
+    /// Optional section to read instead of the whole document: a
+    /// `sections[].section_id` slug (e.g. `retry-policy`), `preamble`, or a
+    /// full section id (`knowledge:docs/x.md#retry-policy`).
+    pub section: Option<String>,
+}
+
+pub async fn read_knowledge_document(params: ReadKnowledgeDocumentParams) -> anyhow::Result<Value> {
+    let document_path = params.document.trim().replace('\\', "/");
+    if document_path.is_empty() {
+        return Err(ToolError::InvalidArgument {
+            param: "document".to_string(),
+            message: "document must not be empty (use the project-relative path returned by search_knowledge)"
+                .to_string(),
+        }
+        .into());
+    }
+    // `knowledge:path#slug` and bare slugs both resolve to the slug.
+    let section = params
+        .section
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.rsplit('#').next().unwrap_or(s).to_string());
+
+    let canonical = resolve_project_path(&params.project)?;
+
+    // Index refresh + raw file read in one blocking task; the lock inside
+    // `with_knowledge_index` keeps the two consistent.
+    let root = canonical;
+    let payload = tokio::task::spawn_blocking(move || {
+        with_knowledge_index(&root, |_changed, index| {
+            let resolved = resolve_project_file(&root, &document_path)?;
+            let rel = resolved
+                .strip_prefix(&root)
+                .map_err(|_| ToolError::AccessDenied {
+                    path: document_path.clone(),
+                })?
+                .to_string_lossy()
+                .replace('\\', "/");
+
+            let doc_id = KnowledgeDocument::doc_id_for(&rel);
+            let doc = index.documents.get(&doc_id).ok_or_else(|| {
+                ToolError::DocumentNotFound {
+                    path: rel.clone(),
+                }
+            })?;
+
+            let source = String::from_utf8(read_regular_file(&resolved)?).map_err(|_| {
+                ToolError::Internal {
+                    message: format!("knowledge document '{rel}' is not valid UTF-8"),
+                }
+            })?;
+
+            let stale = doc
+                .okf
+                .as_ref()
+                .is_some_and(|m| okf::is_stale(m, okf::now_secs()));
+
+            let mut response = Map::new();
+            response.insert("document".into(), json!(doc.file_path));
+            response.insert("doc_id".into(), json!(doc.doc_id));
+            response.insert("title".into(), json!(doc.title));
+            response.insert(
+                "tags".into(),
+                if doc.tags.is_empty() {
+                    Value::Null
+                } else {
+                    json!(doc.tags)
+                },
+            );
+            insert_okf_fields(doc, stale, &mut response);
+            response.insert("front_matter".into(), doc.front_matter_value());
+            response.insert(
+                "related_docs".into(),
+                if doc.links.is_empty() {
+                    Value::Null
+                } else {
+                    json!(doc
+                        .links
+                        .iter()
+                        .map(|l| json!({"target": l.target, "text": l.text}))
+                        .collect::<Vec<_>>())
+                },
+            );
+            response.insert("referenced_by".into(), referenced_by(&index, &rel));
+            response.insert("section_count".into(), json!(doc.sections.len()));
+            response.insert(
+                "sections".into(),
+                json!(doc.sections.iter().map(section_outline).collect::<Vec<_>>()),
+            );
+
+            let steering = match section.as_deref() {
+                Some(slug) => {
+                    let sec = doc
+                        .sections
+                        .iter()
+                        .find(|s| s.section_id == slug)
+                        .ok_or_else(|| ToolError::InvalidArgument {
+                            param: "section".to_string(),
+                            message: format!(
+                                "section '{slug}' not found in '{rel}'; available: {}",
+                                section_id_list(doc)
+                            ),
+                        })?;
+                    response.insert(
+                        "section".into(),
+                        json!({
+                            "section_id": sec.section_id,
+                            "heading": outline_heading(sec),
+                            "hierarchy": sec.hierarchy,
+                            "level": sec.level,
+                            "line_start": sec.line_start,
+                            "line_end": sec.line_end,
+                            "content": slice_lines(&source, sec.line_start, sec.line_end),
+                        }),
+                    );
+                    build_steering(
+                        0.95,
+                        served_reason(doc, stale, &format!(
+                            "section '{slug}' (lines {}–{})",
+                            sec.line_start, sec.line_end
+                        )),
+                        follow_up_tool(doc),
+                        follow_up_target(doc, &root),
+                        Vec::new(),
+                    )
+                }
+                None => {
+                    response.insert("content".into(), json!(source));
+                    response.insert("line_count".into(), json!(source.lines().count()));
+                    build_steering(
+                        0.95,
+                        served_reason(doc, stale, &format!("full document ({rel})")),
+                        follow_up_tool(doc),
+                        follow_up_target(doc, &root),
+                        Vec::new(),
+                    )
+                }
+            };
+
+            response.insert(
+                "guidance".into(),
+                json!({
+                    "next_step": if section.is_some() {
+                        "Navigate sibling sections via `sections` coordinates, or pass a `related_docs` target as `document` to follow the link."
+                    } else {
+                        "Pass `section` with one of the `sections[].section_id` values to fetch only that part of the document."
+                    },
+                    "avoid": if section.is_some() {
+                        "Avoid loading whole documents when one section already answers the question."
+                    } else {
+                        "Avoid re-reading the full document when a single section suffices."
+                    },
+                }),
+            );
+
+            let mut response = Value::Object(response);
+            attach_steering(&mut response, steering);
+            Ok(response)
+        })
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("knowledge indexing task failed: {e}"))??;
+    Ok(payload)
+}
+
+/// Mirror of the `search_knowledge` result metadata: OKF fields are `null`
+/// for plain-Markdown documents.
+fn insert_okf_fields(doc: &KnowledgeDocument, stale: bool, response: &mut Map<String, Value>) {
+    let okf = doc.okf.as_ref();
+    let mut insert = |key: &str, value: Value| {
+        response.insert(key.to_string(), value);
+    };
+    insert("stale", json!(stale));
+    insert(
+        "okf_type",
+        okf.and_then(|m| (!m.doc_type.is_empty()).then(|| json!(m.doc_type)))
+            .unwrap_or(Value::Null),
+    );
+    insert(
+        "description",
+        okf.and_then(|m| m.description.as_deref())
+            .map(|v| json!(v))
+            .unwrap_or(Value::Null),
+    );
+    insert(
+        "resource",
+        okf.and_then(|m| m.resource.as_deref())
+            .map(|v| json!(v))
+            .unwrap_or(Value::Null),
+    );
+    insert(
+        "status",
+        okf.and_then(|m| m.status.as_deref())
+            .map(|v| json!(v))
+            .unwrap_or(Value::Null),
+    );
+    insert(
+        "trust_tier",
+        okf.map(|m| json!(m.trust_tier.as_str()))
+            .unwrap_or(Value::Null),
+    );
+}
+
+/// Reverse edges of the link graph: documents that link to `rel`.
+fn referenced_by(index: &crate::knowledge::KnowledgeIndex, rel: &str) -> Value {
+    let mut refs: Vec<String> = index
+        .documents
+        .values()
+        .filter(|other| other.file_path != rel && other.links.iter().any(|l| l.target == rel))
+        .map(|other| other.file_path.clone())
+        .collect();
+    refs.sort();
+    if refs.is_empty() {
+        Value::Null
+    } else {
+        json!(refs)
+    }
+}
+
+fn section_outline(section: &KnowledgeSection) -> Value {
+    json!({
+        "section_id": section.section_id,
+        "heading": outline_heading(section),
+        "level": section.level,
+        "line_start": section.line_start,
+        "line_end": section.line_end,
+    })
+}
+
+fn outline_heading(section: &KnowledgeSection) -> String {
+    if section.hierarchy.is_empty() {
+        "(preamble)".to_string()
+    } else {
+        section.hierarchy_path()
+    }
+}
+
+/// Exact source slice for a section's 1-based inclusive line range.
+fn slice_lines(source: &str, line_start: usize, line_end: usize) -> String {
+    source
+        .lines()
+        .skip(line_start.saturating_sub(1))
+        .take(line_end.saturating_sub(line_start) + 1)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// All section ids (capped) for the section-not-found error message.
+fn section_id_list(doc: &KnowledgeDocument) -> String {
+    let ids: Vec<&str> = doc.sections.iter().map(|s| s.section_id.as_str()).collect();
+    if ids.len() <= 15 {
+        ids.join(", ")
+    } else {
+        format!("{} … ({} sections)", ids[..15].join(", "), ids.len())
+    }
+}
+
+fn served_reason(doc: &KnowledgeDocument, stale: bool, what: &str) -> String {
+    let mut reason = format!("Served {what} of '{}'.", doc.title);
+    if stale {
+        reason.push_str(" Warning: the document is stale (its `stale_after` instant has passed).");
+    }
+    reason
+}
+
+fn follow_up_tool(doc: &KnowledgeDocument) -> &'static str {
+    if doc.links.is_empty() {
+        "search_knowledge"
+    } else {
+        "read_knowledge_document"
+    }
+}
+
+fn follow_up_target(doc: &KnowledgeDocument, root: &Path) -> Value {
+    match doc.links.first() {
+        Some(link) => json!({
+            "project": root.to_string_lossy(),
+            "document": link.target,
+        }),
+        None => json!({ "project": root.to_string_lossy() }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Two linked documents, one OKF, one plain Markdown, plus an
+    /// unreachable file outside the knowledge index.
+    fn fixture() -> (TempDir, std::path::PathBuf) {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join("docs")).unwrap();
+        std::fs::write(
+            dir.path().join("docs/guide.md"),
+            "---\ntitle: Retry Guide\ntags: [ops, retry]\ntype: Playbook\nstatus: stable\nverified: { by: human:ana, at: 2026-06-25T09:00:00Z }\n---\n# Retry Guide\nPreamble text.\n## Backoff\nExponential backoff with jitter.\nSee [policies](policies.md) and [Overview](/README.md).\n## Deadlines\nPer-attempt deadlines.\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("docs/policies.md"),
+            "Policies live here.\n# Policies\nFollow the [retry guide](guide.md#backoff).\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("notes.txt"), "not indexed\n").unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        (dir, root)
+    }
+
+    async fn read(
+        root: &std::path::Path,
+        document: &str,
+        section: Option<&str>,
+    ) -> anyhow::Result<Value> {
+        read_knowledge_document(ReadKnowledgeDocumentParams {
+            project: root.to_string_lossy().to_string(),
+            document: document.to_string(),
+            section: section.map(str::to_string),
+        })
+        .await
+    }
+
+    /// Structured error envelope for a failing call.
+    fn err_json(value: anyhow::Result<Value>) -> Value {
+        let err = value
+            .expect_err("expected an error")
+            .downcast::<ToolError>()
+            .unwrap();
+        err.to_json()
+    }
+
+    #[tokio::test]
+    async fn whole_document_serves_raw_source_metadata_and_graph() {
+        let (_dir, root) = fixture();
+        let response = read(&root, "docs/guide.md", None).await.unwrap();
+
+        assert_eq!(response["document"], "docs/guide.md");
+        assert_eq!(response["doc_id"], "knowledge:docs/guide.md");
+        assert_eq!(response["title"], "Retry Guide");
+        assert_eq!(response["tags"], json!(["ops", "retry"]));
+        assert_eq!(response["okf_type"], "Playbook");
+        assert_eq!(response["trust_tier"], "human-reviewed");
+        assert_eq!(response["stale"], false);
+        // Raw source, front matter included, byte-faithful.
+        let source = std::fs::read_to_string(root.join("docs/guide.md")).unwrap();
+        assert_eq!(response["content"], source);
+        assert_eq!(response["line_count"], source.lines().count());
+        // Section outline with line coordinates.
+        let ids: Vec<&str> = response["sections"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|s| s["section_id"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            ids,
+            vec![
+                "retry-guide",
+                "retry-guide-backoff",
+                "retry-guide-deadlines"
+            ]
+        );
+        // Parsed front matter bag including unmodeled keys.
+        assert_eq!(response["front_matter"]["type"], "Playbook");
+        // Link graph in both directions.
+        let targets: Vec<&str> = response["related_docs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|l| l["target"].as_str().unwrap())
+            .collect();
+        assert_eq!(targets, vec!["docs/policies.md", "README.md"]);
+        assert_eq!(response["referenced_by"], json!(["docs/policies.md"]));
+    }
+
+    #[tokio::test]
+    async fn section_read_serves_exact_line_range() {
+        let (_dir, root) = fixture();
+        let source = std::fs::read_to_string(root.join("docs/guide.md")).unwrap();
+
+        // Bare slug…
+        let response = read(&root, "docs/guide.md", Some("retry-guide-backoff"))
+            .await
+            .unwrap();
+        let section = &response["section"];
+        assert_eq!(section["heading"], "Retry Guide > Backoff");
+        assert_eq!(section["line_start"], 10);
+        assert_eq!(section["line_end"], 12);
+        let expected: Vec<&str> = source.lines().skip(9).take(3).collect();
+        assert_eq!(section["content"], expected.join("\n"));
+        // …and the full section id form from search results.
+        let response = read(
+            &root,
+            "docs/guide.md",
+            Some("knowledge:docs/guide.md#retry-guide-deadlines"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(response["section"]["section_id"], "retry-guide-deadlines");
+        // The outline is still present for navigation, the full text is not.
+        assert_eq!(response["section_count"], 3);
+        assert!(response["content"].is_null());
+    }
+
+    #[tokio::test]
+    async fn preamble_section_is_served() {
+        let (_dir, root) = fixture();
+        let response = read(&root, "docs/policies.md", Some("preamble"))
+            .await
+            .unwrap();
+        assert_eq!(response["section"]["heading"], "(preamble)");
+        assert_eq!(response["section"]["content"], "Policies live here.");
+    }
+
+    #[tokio::test]
+    async fn unknown_document_section_and_extension_fail_with_codes() {
+        let (_dir, root) = fixture();
+
+        let err = err_json(read(&root, "docs/missing.md", None).await);
+        assert_eq!(err["error"]["code"], "DOCUMENT_NOT_FOUND");
+        // Exists on disk but not a knowledge file.
+        let err = err_json(read(&root, "notes.txt", None).await);
+        assert_eq!(err["error"]["code"], "DOCUMENT_NOT_FOUND");
+        let err = err_json(read(&root, "docs/guide.md", Some("nope")).await);
+        assert_eq!(err["error"]["code"], "INVALID_ARGUMENT");
+        assert!(err["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("retry-guide-backoff"));
+    }
+
+    #[tokio::test]
+    async fn traversal_and_absolute_document_paths_are_denied() {
+        let (_dir, root) = fixture();
+        // A Markdown file outside the project must not be served even when it
+        // exists (unique name so parallel test binaries cannot collide).
+        let outside = _dir
+            .path()
+            .parent()
+            .unwrap()
+            .join(format!("pitlane-read-outside-{}.md", std::process::id()));
+        std::fs::write(&outside, "# Outside\n").unwrap();
+
+        let err = err_json(read(&root, "../outside.md", None).await);
+        assert_eq!(err["error"]["code"], "ACCESS_DENIED");
+        let err = err_json(read(&root, &outside.to_string_lossy(), None).await);
+        assert_eq!(err["error"]["code"], "ACCESS_DENIED");
+        let _ = std::fs::remove_file(outside);
+    }
+
+    #[tokio::test]
+    async fn stale_okf_documents_are_flagged() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("old.md"),
+            "---\ntype: Metric\nstale_after: 2000-01-01T00:00:00Z\n---\n# Old\nBody.\n",
+        )
+        .unwrap();
+        let root = dir.path().canonicalize().unwrap();
+
+        let response = read(&root, "old.md", Some("old")).await.unwrap();
+        assert_eq!(response["stale"], true);
+        assert!(response["steering"]["why_this_matched"]
+            .as_str()
+            .unwrap()
+            .contains("stale"));
+    }
+}

--- a/src/tools/search_knowledge.rs
+++ b/src/tools/search_knowledge.rs
@@ -565,6 +565,22 @@ pub(crate) fn maybe_spawn_knowledge_embeds(
     });
 }
 
+/// True when the on-disk embedding store is compatible with `cfg` and covers
+/// every non-empty section of `index`. Used by the one-shot CLI to decide
+/// whether embeddings must be regenerated synchronously before a search (the
+/// MCP server instead refreshes them via `maybe_spawn_knowledge_embeds`).
+pub fn knowledge_store_fresh(
+    canonical: &Path,
+    index: &crate::knowledge::KnowledgeIndex,
+    cfg: &EmbedConfig,
+) -> bool {
+    match knowledge_dir(canonical) {
+        Ok(kdir) => load_compatible_store(&kdir.join("embeddings.bin"), cfg)
+            .is_some_and(|store| knowledge_embeddings_complete(index, &store)),
+        Err(_) => false,
+    }
+}
+
 fn knowledge_embeddings_complete(
     index: &crate::knowledge::KnowledgeIndex,
     store: &EmbedStore,

--- a/src/tools/search_knowledge.rs
+++ b/src/tools/search_knowledge.rs
@@ -762,16 +762,25 @@ mod tests {
             "kb/old.md",
             "---\ntype: Metric\nstale_after: 2000-01-01T00:00:00Z\n---\n# Metric\nBody.\n",
         );
+        // The spec §5.5 date-only spelling must be reported and penalized too.
+        let date_doc = document::parse_markdown(
+            "kb/old-date.md",
+            "---\ntype: Metric\nstale_after: 2000-01-01\n---\n# Metric\nBody.\n",
+        );
         index.documents.insert(doc.doc_id.clone(), doc);
+        index.documents.insert(date_doc.doc_id.clone(), date_doc);
         let base = DocFilter {
             tag: None,
             okf_type: None,
             status: None,
             min_trust: None,
         };
-        let cand = resolve_candidate(&index, "knowledge:kb/old.md#metric", &base).unwrap();
-        assert!(cand.stale);
-        assert_eq!(cand.metadata_adjustment, -0.10);
+        for slug in ["kb/old.md", "kb/old-date.md"] {
+            let cand =
+                resolve_candidate(&index, &format!("knowledge:{slug}#metric"), &base).unwrap();
+            assert!(cand.stale, "{slug} should be stale");
+            assert_eq!(cand.metadata_adjustment, -0.10, "{slug}");
+        }
     }
 
     #[tokio::test]

--- a/src/tools/search_knowledge.rs
+++ b/src/tools/search_knowledge.rs
@@ -301,7 +301,7 @@ pub async fn search_knowledge(params: SearchKnowledgeParams) -> anyhow::Result<V
             "next_step": if results.is_empty() {
                 "No knowledge sections matched. Try a broader query or check that Markdown files exist in the project (they must not be gitignored)."
             } else {
-                "Use read_code_unit with file_path and line_start/line_end to open the full section, then follow links in neighboring docs."
+                "Use read_knowledge_document with file_path to open the full document, or pass section_id to fetch only that section."
             },
             "avoid": "Avoid loading whole documentation trees into context; fetch sections on demand.",
         },
@@ -323,13 +323,12 @@ pub async fn search_knowledge(params: SearchKnowledgeParams) -> anyhow::Result<V
         if results.is_empty() {
             "search_content"
         } else {
-            "read_code_unit"
+            "read_knowledge_document"
         },
         match &top {
             Some(r) => json!({
-                "file_path": r["file_path"],
-                "line_start": r["line_start"],
-                "line_end": r["line_end"],
+                "document": r["file_path"],
+                "section": r["section_id"],
             }),
             None => json!(params.project),
         },


### PR DESCRIPTION
## Summary

Completes the Phase 3 item **"Allow retrieval of full source documents/sections after search"** of #118 — the only Phase 3 item that is also an explicit acceptance criterion ("The original Markdown section/document can be retrieved for additional LLM context").

Two commits:
1. New public-tier MCP tool `read_knowledge_document`.
2. CLI subcommands `pitlane search-knowledge` and `pitlane read-knowledge-document` (the CLI previously had no knowledge surface at all — `search_knowledge` was MCP-only since Phase 1).

## MCP tool: `read_knowledge_document`

- **Whole document** (`document`: project-relative path from search results): serves the raw source Markdown from disk — front matter included — plus metadata.
- **Single section** (`section`: bare slug, `preamble`, or full id `knowledge:docs/x.md#slug`): serves the section's exact 1-based inclusive line range from the source file.
- The incremental index refresh and the raw file read run under the same project lock (`with_knowledge_index`), so served text always matches the parsed section coordinates.
- Responses include title/tags, OKF metadata (`okf_type`, `description`, `resource`, `status`, `trust_tier`, `stale`), the parsed `front_matter` bag, a section outline with line ranges, and the link graph in both directions: `related_docs` (outgoing) and `referenced_by` (incoming — cheap reverse-edge scan over the in-memory index).
- Structured errors: new `DOCUMENT_NOT_FOUND` variant (unindexed/non-Markdown paths, hint points at `search_knowledge`); `INVALID_ARGUMENT` with the available section ids for unknown sections; `ACCESS_DENIED` for `../` traversal and absolute paths (reuses `resolve_project_file`).

`search_knowledge`'s guidance and steering now hand off to `read_knowledge_document` instead of `read_code_unit`.

## CLI: `search-knowledge` / `read-knowledge-document`

- `pitlane search-knowledge <project> <query>` supports the same filters as the MCP tool (`--tag`, `--path-filter`, `--okf-type`, `--status`, `--min-trust`, `--limit`). The CLI is one-shot, so it refreshes the knowledge index and regenerates embeddings **synchronously** when the store is missing or stale — same rationale as the existing CLI `index` command — letting semantic ranking work instead of silently degrading to lexical-only. Embedding failures warn on stderr and the search still returns lexical results. New pub helper `knowledge_store_fresh` reuses the server's freshness check.
- `pitlane read-knowledge-document <project> <document> [--section SLUG]` needs no embeddings and delegates directly.

## Tests

- 6 new tool tests (whole-document fidelity, exact section line ranges, preamble, structured error codes, traversal denial, stale flagging) + 1 new `DOCUMENT_NOT_FOUND` error-variant test.
- 4 new CLI tests (clap parsing + `run_command` end-to-end for both commands).
- `cargo test` all suites green (747 lib + integration), `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean.
- Smoke-tested both surfaces for real: MCP server over stdio (tools/list, whole-doc + section reads, `path` alias, structured error) and the `pitlane` binary against this repo (search with `--limit`, section read via `--section navigation`).

## Docs

- `docs/tools.md`: new `read_knowledge_document` section; search_knowledge bullet updated to the new handoff.
- `README.md` + `AGENTS.md`: added to the default public tier and workflow/navigation guidance (also fixed the duplicated item-7 numbering in AGENTS.md).

Refs #118 (Phase 3). Remaining Phase 3 items after this: unified ranking across code + knowledge, and a unified MCP search experience.